### PR TITLE
prevent app from crashing when sd-card data is not valid anymore

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/adapter/SongFileAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/SongFileAdapter.kt
@@ -142,7 +142,7 @@ class SongFileAdapter(
     }
 
     override fun getPopupText(position: Int): String {
-        return getSectionName(position)
+        return if (position >= dataSet.lastIndex) "" else getSectionName(position)
     }
 
     private fun getSectionName(position: Int): String {


### PR DESCRIPTION
A quick workaround for #1187

The true problem is probably dataSet getting updated too early