### PR TITLE
Monet based icon for Android 13 users

### DIFF
--- a/app/src/main/res/drawable/retro_you_icon.xml
+++ b/app/src/main/res/drawable/retro_you_icon.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M15.63,11.32l-5.27,-3A0.79,0.79 0,0 0,9.18 9V15a0.79,0.79 0,0 0,1.18 0.68l5.27,-3A0.79,0.79 0,0 0,15.63 11.32Z"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.63,11.77h0a1.57,1.57 0,0 0,-1.56 -1.58H9.84l1.75,3.06A1.57,1.57 0,0 0,12.63 11.77Z"
+        android:strokeAlpha="0.19"
+        android:fillAlpha="0.19"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9.18,13.34V15a0.79,0.79 0,0 0,1.18 0.68l2.09,-1.2 -0.15,-0.26 -0.59,-1a1.77,1.77 0,0 1,-0.56 0.09Z"
+        android:strokeWidth="0.8"
+        android:strokeColor="#000"
+        android:fillAlpha="0.2"/>
+    <path
+        android:pathData="M9.2,10.29h1.91a1.53,1.53 0,0 1,1.53 1.53v0a1.53,1.53 0,0 1,-1.53 1.53H9.2a0,0 0,0 1,0 0V10.29A0,0 0,0 1,9.2 10.29Z"
+        android:strokeWidth="0.8"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/retro_you_icon" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/retro_you_icon" />
 </adaptive-icon>


### PR DESCRIPTION
NOTE: This feature will only work for Android 13 users as Google restricted themed icon support for their own apps. Third-party app support has to be added by Google itself for this work on android 12. Till then, you can use a third party icon set to the material you icons