### PR TITLE
Localized sorting

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumDetailsFragment.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import java.text.Collator
 
 class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_details),
     IAlbumClickListener, ICabHolder {
@@ -437,15 +438,13 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
                     o2.trackNumber
                 )
             }
-            SONG_A_Z -> album.songs.sortedWith { o1, o2 ->
-                o1.title.compareTo(
-                    o2.title
-                )
+            SONG_A_Z -> {
+                val collator = Collator.getInstance()
+                album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
             }
-            SONG_Z_A -> album.songs.sortedWith { o1, o2 ->
-                o2.title.compareTo(
-                    o1.title
-                )
+            SONG_Z_A -> {
+                val collator = Collator.getInstance()
+                album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
             }
             SONG_DURATION -> album.songs.sortedWith { o1, o2 ->
                 o1.duration.compareTo(

--- a/app/src/main/java/code/name/monkey/retromusic/model/Artist.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/model/Artist.kt
@@ -17,6 +17,7 @@ package code.name.monkey.retromusic.model
 import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
+import java.text.Collator
 
 data class Artist(
     val id: Long,
@@ -60,37 +61,34 @@ data class Artist(
         get() = albums.flatMap { it.songs }
 
     val sortedSongs: List<Song>
-        get() = songs.sortedWith(
-            when (PreferenceUtil.artistDetailSongSortOrder) {
-                SortOrder.ArtistSongSortOrder.SONG_A_Z -> { o1, o2 ->
-                    o1.title.compareTo(
-                        o2.title
-                    )
-                }
-                SortOrder.ArtistSongSortOrder.SONG_Z_A -> { o1, o2 ->
-                    o2.title.compareTo(
-                        o1.title
-                    )
-                }
-                SortOrder.ArtistSongSortOrder.SONG_ALBUM -> { o1, o2 ->
-                    o1.albumName.compareTo(
-                        o2.albumName
-                    )
-                }
-                SortOrder.ArtistSongSortOrder.SONG_YEAR -> { o1, o2 ->
-                    o2.year.compareTo(
-                        o1.year
-                    )
-                }
-                SortOrder.ArtistSongSortOrder.SONG_DURATION -> { o1, o2 ->
-                    o1.duration.compareTo(
-                        o2.duration
-                    )
-                }
-                else -> {
-                    throw IllegalArgumentException("invalid ${PreferenceUtil.artistDetailSongSortOrder}")
-                }
-            })
+        get() {
+            val collator = Collator.getInstance()
+            return songs.sortedWith(
+                when (PreferenceUtil.artistDetailSongSortOrder) {
+                    SortOrder.ArtistSongSortOrder.SONG_A_Z -> { o1, o2 ->
+                        collator.compare(o1.title, o2.title)
+                    }
+                    SortOrder.ArtistSongSortOrder.SONG_Z_A -> { o1, o2 ->
+                        collator.compare(o2.title, o1.title)
+                    }
+                    SortOrder.ArtistSongSortOrder.SONG_ALBUM -> { o1, o2 ->
+                        collator.compare(o1.albumName, o2.albumName)
+                    }
+                    SortOrder.ArtistSongSortOrder.SONG_YEAR -> { o1, o2 ->
+                        o2.year.compareTo(
+                            o1.year
+                        )
+                    }
+                    SortOrder.ArtistSongSortOrder.SONG_DURATION -> { o1, o2 ->
+                        o1.duration.compareTo(
+                            o2.duration
+                        )
+                    }
+                    else -> {
+                        throw IllegalArgumentException("invalid ${PreferenceUtil.artistDetailSongSortOrder}")
+                    }
+                })
+        }
 
     fun safeGetFirstAlbum(): Album {
         return albums.firstOrNull() ?: Album.empty

--- a/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
@@ -75,34 +75,34 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
         songs: List<Song>
     ): List<Album> {
         val grouped = songs.groupBy { it.albumId }.map { Album(it.key, it.value) }
+        val collator = Collator.getInstance()
         return when (PreferenceUtil.albumSortOrder) {
             SortOrder.AlbumSortOrder.ALBUM_A_Z -> {
-                val collator = Collator.getInstance()
                 grouped.sortedWith { a1, a2 -> collator.compare(a1.title, a2.title) }
             }
             SortOrder.AlbumSortOrder.ALBUM_Z_A -> {
-                val collator = Collator.getInstance()
                 grouped.sortedWith { a1, a2 -> collator.compare(a2.title, a1.title) }
             }
             SortOrder.AlbumSortOrder.ALBUM_ARTIST -> {
-                val collator = Collator.getInstance()
                 grouped.sortedWith { a1, a2 -> collator.compare(a1.albumArtist, a2.albumArtist) }
+            }
+            SortOrder.AlbumSortOrder.ALBUM_NUMBER_OF_SONGS -> {
+                grouped.sortedByDescending { it.songCount }
             }
             else -> grouped
         }
     }
 
     private fun sortAlbumSongs(album: Album): Album {
+        val collator = Collator.getInstance()
         val songs = when (PreferenceUtil.albumDetailSongSortOrder) {
             SortOrder.AlbumSongSortOrder.SONG_TRACK_LIST -> album.songs.sortedWith { o1, o2 ->
                 o1.trackNumber.compareTo(o2.trackNumber)
             }
             SortOrder.AlbumSongSortOrder.SONG_A_Z -> {
-                val collator = Collator.getInstance()
                 album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
             }
             SortOrder.AlbumSongSortOrder.SONG_Z_A -> {
-                val collator = Collator.getInstance()
                 album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
             }
             SortOrder.AlbumSongSortOrder.SONG_DURATION -> album.songs.sortedWith { o1, o2 ->

--- a/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
@@ -19,6 +19,7 @@ import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.util.PreferenceUtil
+import java.text.Collator
 
 
 /**
@@ -65,8 +66,7 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
         )
         val songs = songRepository.songs(cursor)
         val album = Album(albumId, songs)
-        sortAlbumSongs(album)
-        return album
+        return sortAlbumSongs(album)
     }
 
     // We don't need sorted list of songs (with sortAlbumSongs())
@@ -74,11 +74,22 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
     fun splitIntoAlbums(
         songs: List<Song>
     ): List<Album> {
-        return if (PreferenceUtil.albumSortOrder != SortOrder.AlbumSortOrder.ALBUM_NUMBER_OF_SONGS) songs.groupBy { it.albumId }
-            .map { Album(it.key, it.value) }
-        // We can't sort Album with the help of MediaStore so a hack
-        else songs.groupBy { it.albumId }.map { Album(it.key, it.value) }
-            .sortedByDescending { it.songCount }
+        val grouped = songs.groupBy { it.albumId }.map { Album(it.key, it.value) }
+        return when (PreferenceUtil.albumSortOrder) {
+            SortOrder.AlbumSortOrder.ALBUM_A_Z -> {
+                val collator = Collator.getInstance()
+                grouped.sortedWith { a1, a2 -> collator.compare(a1.title, a2.title) }
+            }
+            SortOrder.AlbumSortOrder.ALBUM_Z_A -> {
+                val collator = Collator.getInstance()
+                grouped.sortedWith { a1, a2 -> collator.compare(a2.title, a1.title) }
+            }
+            SortOrder.AlbumSortOrder.ALBUM_ARTIST -> {
+                val collator = Collator.getInstance()
+                grouped.sortedWith { a1, a2 -> collator.compare(a1.albumArtist, a2.albumArtist) }
+            }
+            else -> grouped
+        }
     }
 
     private fun sortAlbumSongs(album: Album): Album {
@@ -86,11 +97,13 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
             SortOrder.AlbumSongSortOrder.SONG_TRACK_LIST -> album.songs.sortedWith { o1, o2 ->
                 o1.trackNumber.compareTo(o2.trackNumber)
             }
-            SortOrder.AlbumSongSortOrder.SONG_A_Z -> album.songs.sortedWith { o1, o2 ->
-                o1.title.compareTo(o2.title)
+            SortOrder.AlbumSongSortOrder.SONG_A_Z -> {
+                val collator = Collator.getInstance()
+                album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
             }
-            SortOrder.AlbumSongSortOrder.SONG_Z_A -> album.songs.sortedWith { o1, o2 ->
-                o2.title.compareTo(o1.title)
+            SortOrder.AlbumSongSortOrder.SONG_Z_A -> {
+                val collator = Collator.getInstance()
+                album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
             }
             SortOrder.AlbumSongSortOrder.SONG_DURATION -> album.songs.sortedWith { o1, o2 ->
                 o1.duration.compareTo(o2.duration)

--- a/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
@@ -20,6 +20,7 @@ import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
 import code.name.monkey.retromusic.util.PreferenceUtil
+import java.text.Collator
 
 interface ArtistRepository {
     fun artists(): List<Artist>
@@ -103,7 +104,8 @@ class RealArtistRepository(
                 getSongLoaderSortOrder()
             )
         )
-        return splitIntoArtists(albumRepository.splitIntoAlbums(songs))
+        val artists = splitIntoArtists(albumRepository.splitIntoAlbums(songs))
+        return sortArtists(artists)
     }
 
     override fun albumArtists(): List<Artist> {
@@ -115,7 +117,8 @@ class RealArtistRepository(
                         if (PreferenceUtil.artistSortOrder == SortOrder.ArtistSortOrder.ARTIST_A_Z) "" else " DESC"
             )
         )
-        return splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
+        val artists = splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
+        return sortArtists(artists)
     }
 
     override fun albumArtists(query: String): List<Artist> {
@@ -126,7 +129,8 @@ class RealArtistRepository(
                 getSongLoaderSortOrder()
             )
         )
-        return splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
+        val artists = splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
+        return sortArtists(artists)
     }
 
     override fun artists(query: String): List<Artist> {
@@ -137,7 +141,8 @@ class RealArtistRepository(
                 getSongLoaderSortOrder()
             )
         )
-        return splitIntoArtists(albumRepository.splitIntoAlbums(songs))
+        val artists = splitIntoArtists(albumRepository.splitIntoAlbums(songs))
+        return sortArtists(artists)
     }
 
 
@@ -164,5 +169,19 @@ class RealArtistRepository(
     fun splitIntoArtists(albums: List<Album>): List<Artist> {
         return albums.groupBy { it.artistId }
             .map { Artist(it.key, it.value) }
+    }
+
+    private fun sortArtists(artists: List<Artist>): List<Artist> {
+        return when (PreferenceUtil.artistSortOrder) {
+            SortOrder.ArtistSortOrder.ARTIST_A_Z -> {
+                val collator = Collator.getInstance()
+                artists.sortedWith{ a1, a2 -> collator.compare(a1.name, a2.name) }
+            }
+            SortOrder.ArtistSortOrder.ARTIST_Z_A -> {
+                val collator = Collator.getInstance()
+                artists.sortedWith{ a1, a2 -> collator.compare(a2.name, a1.name) }
+            }
+            else -> artists
+        }
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
@@ -172,14 +172,13 @@ class RealArtistRepository(
     }
 
     private fun sortArtists(artists: List<Artist>): List<Artist> {
+        val collator = Collator.getInstance()
         return when (PreferenceUtil.artistSortOrder) {
             SortOrder.ArtistSortOrder.ARTIST_A_Z -> {
-                val collator = Collator.getInstance()
-                artists.sortedWith{ a1, a2 -> collator.compare(a1.name, a2.name) }
+                artists.sortedWith { a1, a2 -> collator.compare(a1.name, a2.name) }
             }
             SortOrder.ArtistSortOrder.ARTIST_Z_A -> {
-                val collator = Collator.getInstance()
-                artists.sortedWith{ a1, a2 -> collator.compare(a2.name, a1.name) }
+                artists.sortedWith { a1, a2 -> collator.compare(a2.name, a1.name) }
             }
             else -> artists
         }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -68,29 +68,24 @@ class RealSongRepository(private val context: Context) : SongRepository {
             } while (cursor.moveToNext())
         }
         cursor?.close()
+        val collator = Collator.getInstance()
         return when (PreferenceUtil.songSortOrder) {
             SortOrder.SongSortOrder.SONG_A_Z -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s1.title, s2.title) }
             }
             SortOrder.SongSortOrder.SONG_Z_A -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s2.title, s1.title) }
             }
             SortOrder.SongSortOrder.SONG_ALBUM -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s1.albumName, s2.albumName) }
             }
             SortOrder.SongSortOrder.SONG_ALBUM_ARTIST -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s1.albumArtist, s2.albumArtist) }
             }
             SortOrder.SongSortOrder.SONG_ARTIST -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s1.artistName, s2.artistName) }
             }
             SortOrder.SongSortOrder.COMPOSER -> {
-                val collator = Collator.getInstance()
                 songs.sortedWith{ s1, s2 -> collator.compare(s1.composer, s2.composer) }
             }
             else -> songs

--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -28,9 +28,11 @@ import code.name.monkey.retromusic.extensions.getInt
 import code.name.monkey.retromusic.extensions.getLong
 import code.name.monkey.retromusic.extensions.getString
 import code.name.monkey.retromusic.extensions.getStringOrNull
+import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.providers.BlacklistStore
 import code.name.monkey.retromusic.util.PreferenceUtil
+import java.text.Collator
 
 /**
  * Created by hemanths on 10/08/17.
@@ -66,7 +68,33 @@ class RealSongRepository(private val context: Context) : SongRepository {
             } while (cursor.moveToNext())
         }
         cursor?.close()
-        return songs
+        return when (PreferenceUtil.songSortOrder) {
+            SortOrder.SongSortOrder.SONG_A_Z -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s1.title, s2.title) }
+            }
+            SortOrder.SongSortOrder.SONG_Z_A -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s2.title, s1.title) }
+            }
+            SortOrder.SongSortOrder.SONG_ALBUM -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s1.albumName, s2.albumName) }
+            }
+            SortOrder.SongSortOrder.SONG_ALBUM_ARTIST -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s1.albumArtist, s2.albumArtist) }
+            }
+            SortOrder.SongSortOrder.SONG_ARTIST -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s1.artistName, s2.artistName) }
+            }
+            SortOrder.SongSortOrder.COMPOSER -> {
+                val collator = Collator.getInstance()
+                songs.sortedWith{ s1, s2 -> collator.compare(s1.composer, s2.composer) }
+            }
+            else -> songs
+        }
     }
 
     override fun song(cursor: Cursor?): Song {


### PR DESCRIPTION
`java.text.Collator` is used to sort the songs, albums and artists in a localized way. Thus, in zh-CN locale, the names are sorted by pronunciation (in pinyin). Also, the names with accents should be sorted more properly in this way.

Currently the sorted order in RetroMusicPlayer is incorrect like:
一
万
三

After the fix, the ordering is correct in zh-CN locale:
三 (pronunced as "san")
万 (pronunced as "wan")
一 (pronunced as "yi")


Implements #1294 