### PR TITLE
Fixed something about notification and lockscreen.

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/LockScreenActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/LockScreenActivity.kt
@@ -26,13 +26,10 @@ import code.name.monkey.retromusic.extensions.hideStatusBar
 import code.name.monkey.retromusic.extensions.setTaskDescriptionColorAuto
 import code.name.monkey.retromusic.extensions.whichFragment
 import code.name.monkey.retromusic.fragments.player.lockscreen.LockScreenControlsFragment
-import code.name.monkey.retromusic.glide.BlurTransformation
 import code.name.monkey.retromusic.glide.GlideApp
 import code.name.monkey.retromusic.glide.RetroGlideExtension
 import code.name.monkey.retromusic.glide.RetroMusicColoredTarget
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
-import code.name.monkey.retromusic.util.PreferenceUtil
-import code.name.monkey.retromusic.util.PreferenceUtil.isAlbumArtOnLockScreen
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.r0adkll.slidr.Slidr
 import com.r0adkll.slidr.model.SlidrConfig
@@ -91,7 +88,7 @@ class LockScreenActivity : AbsMusicServiceActivity() {
         } else {
             window.addFlags(
                 WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-                //          or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+              //          or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
             )
         }
     }
@@ -107,31 +104,16 @@ class LockScreenActivity : AbsMusicServiceActivity() {
     }
 
     private fun updateSongs() {
-        if (!isAlbumArtOnLockScreen) {
-            binding.image.setImageResource(R.drawable.default_audio_art)
-            return
-        }
-
         val song = MusicPlayerRemote.currentSong
-
         GlideApp.with(this)
             .asBitmapPalette()
             .songCoverOptions(song)
             .load(RetroGlideExtension.getSongModel(song))
-            .transition(RetroGlideExtension.getDefaultTransition())
+            .dontAnimate()
             .into(object : RetroMusicColoredTarget(binding.image) {
                 override fun onColorReady(colors: MediaNotificationProcessor) {
                     fragment?.setColor(colors)
                 }
             })
-
-        if (PreferenceUtil.isBlurredAlbumArt) {
-            GlideApp.with(this)
-                .load(RetroGlideExtension.getSongModel(song))
-                .transition(RetroGlideExtension.getDefaultTransition())
-                .transform(BlurTransformation.Builder(this).blurRadius(25f).build())
-                .into(binding.ivBlurredAlbumArt)
-        }
-
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/activities/LockScreenActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/LockScreenActivity.kt
@@ -26,10 +26,13 @@ import code.name.monkey.retromusic.extensions.hideStatusBar
 import code.name.monkey.retromusic.extensions.setTaskDescriptionColorAuto
 import code.name.monkey.retromusic.extensions.whichFragment
 import code.name.monkey.retromusic.fragments.player.lockscreen.LockScreenControlsFragment
+import code.name.monkey.retromusic.glide.BlurTransformation
 import code.name.monkey.retromusic.glide.GlideApp
 import code.name.monkey.retromusic.glide.RetroGlideExtension
 import code.name.monkey.retromusic.glide.RetroMusicColoredTarget
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
+import code.name.monkey.retromusic.util.PreferenceUtil
+import code.name.monkey.retromusic.util.PreferenceUtil.isAlbumArtOnLockScreen
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.r0adkll.slidr.Slidr
 import com.r0adkll.slidr.model.SlidrConfig
@@ -88,7 +91,7 @@ class LockScreenActivity : AbsMusicServiceActivity() {
         } else {
             window.addFlags(
                 WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-              //          or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                //          or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
             )
         }
     }
@@ -104,16 +107,31 @@ class LockScreenActivity : AbsMusicServiceActivity() {
     }
 
     private fun updateSongs() {
+        if (!isAlbumArtOnLockScreen) {
+            binding.image.setImageResource(R.drawable.default_audio_art)
+            return
+        }
+
         val song = MusicPlayerRemote.currentSong
+
         GlideApp.with(this)
             .asBitmapPalette()
             .songCoverOptions(song)
             .load(RetroGlideExtension.getSongModel(song))
-            .dontAnimate()
+            .transition(RetroGlideExtension.getDefaultTransition())
             .into(object : RetroMusicColoredTarget(binding.image) {
                 override fun onColorReady(colors: MediaNotificationProcessor) {
                     fragment?.setColor(colors)
                 }
             })
+
+        if (PreferenceUtil.isBlurredAlbumArt) {
+            GlideApp.with(this)
+                .load(RetroGlideExtension.getSongModel(song))
+                .transition(RetroGlideExtension.getDefaultTransition())
+                .transform(BlurTransformation.Builder(this).blurRadius(25f).build())
+                .into(binding.ivBlurredAlbumArt)
+        }
+
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/base/AbsPlayerControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/base/AbsPlayerControlsFragment.kt
@@ -155,6 +155,11 @@ abstract class AbsPlayerControlsFragment(@LayoutRes layout: Int) : AbsMusicServi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         progressViewUpdateHelper = MusicProgressViewUpdateHelper(this)
+        if (PreferenceUtil.circlePlayButton) {
+            requireContext().theme.applyStyle(R.style.CircleFABOverlay, true)
+        } else {
+            requireContext().theme.applyStyle(R.style.RoundedFABOverlay, true)
+        }
     }
 
     fun View.showBounceAnimation() {

--- a/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
@@ -23,6 +23,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.pm.ServiceInfo
 import android.database.ContentObserver
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.drawable.Drawable
 import android.media.AudioManager
 import android.os.*
@@ -1021,7 +1022,7 @@ class MusicService : MediaBrowserServiceCompat(),
             .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, null)
             .putLong(MediaMetadataCompat.METADATA_KEY_NUM_TRACKS, playingQueue.size.toLong())
 
-        if (isAlbumArtOnLockScreen) {
+        if (isAlbumArtOnLockScreen || VERSION.SDK_INT == 33) {
             // val screenSize: Point = RetroUtil.getScreenSize(this)
             val request = GlideApp.with(this)
                 .asBitmap()
@@ -1036,6 +1037,13 @@ class MusicService : MediaBrowserServiceCompat(),
                 CustomTarget<Bitmap?>(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL) {
                 override fun onLoadFailed(errorDrawable: Drawable?) {
                     super.onLoadFailed(errorDrawable)
+                    metaData.putBitmap(
+                        MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
+                        BitmapFactory.decodeResource(
+                            resources,
+                            R.drawable.default_audio_art
+                        )
+                    )
                     mediaSession?.setMetadata(metaData.build())
                     onCompletion()
                 }

--- a/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
@@ -70,7 +70,6 @@ import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.MusicUtil.toggleFavorite
 import code.name.monkey.retromusic.util.PackageValidator
 import code.name.monkey.retromusic.util.PreferenceUtil.crossFadeDuration
-import code.name.monkey.retromusic.util.PreferenceUtil.isAlbumArtOnLockScreen
 import code.name.monkey.retromusic.util.PreferenceUtil.isBluetoothSpeaker
 import code.name.monkey.retromusic.util.PreferenceUtil.isBlurredAlbumArt
 import code.name.monkey.retromusic.util.PreferenceUtil.isClassicNotification
@@ -1022,19 +1021,13 @@ class MusicService : MediaBrowserServiceCompat(),
             .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, null)
             .putLong(MediaMetadataCompat.METADATA_KEY_NUM_TRACKS, playingQueue.size.toLong())
 
-        if (isAlbumArtOnLockScreen || VERSION.SDK_INT == 33) {
-            // val screenSize: Point = RetroUtil.getScreenSize(this)
-            val request = GlideApp.with(this)
+            // there only about notification's album art, so remove "isAlbumArtOnLockScreen" and "isBlurredAlbumArt"
+            GlideApp.with(this)
                 .asBitmap()
                 .songCoverOptions(song)
                 .load(getSongModel(song))
                 .transition(getDefaultTransition())
-
-            if (isBlurredAlbumArt) {
-                request.transform(BlurTransformation.Builder(this@MusicService).build())
-            }
-            request.into(object :
-                CustomTarget<Bitmap?>(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL) {
+                .into(object : CustomTarget<Bitmap?>(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL) {
                 override fun onLoadFailed(errorDrawable: Drawable?) {
                     super.onLoadFailed(errorDrawable)
                     metaData.putBitmap(
@@ -1062,10 +1055,6 @@ class MusicService : MediaBrowserServiceCompat(),
 
                 override fun onLoadCleared(placeholder: Drawable?) {}
             })
-        } else {
-            mediaSession?.setMetadata(metaData.build())
-            onCompletion()
-        }
     }
 
     private fun handleChangeInternal(what: String) {

--- a/app/src/main/java/code/name/monkey/retromusic/util/PreferenceUtil.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/PreferenceUtil.kt
@@ -263,7 +263,7 @@ object PreferenceUtil {
 
     val isAlbumArtOnLockScreen
         get() = sharedPreferences.getBoolean(
-            ALBUM_ART_ON_LOCK_SCREEN, false
+            ALBUM_ART_ON_LOCK_SCREEN, true
         )
 
     val isAudioDucking

--- a/app/src/main/java/code/name/monkey/retromusic/views/HeightFitSquareLayout.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/views/HeightFitSquareLayout.kt
@@ -20,7 +20,7 @@ import android.widget.FrameLayout
 class HeightFitSquareLayout  @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = -1
+    defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr){
     private var forceSquare = true
 

--- a/app/src/main/java/code/name/monkey/retromusic/views/StatusBarView.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/views/StatusBarView.kt
@@ -21,7 +21,7 @@ import android.view.View
 class StatusBarView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = -1
+    defStyleAttr: Int = 0
 ) : View(context, attrs, defStyleAttr) {
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/app/src/main/res/layout-land/activity_lock_screen.xml
+++ b/app/src/main/res/layout-land/activity_lock_screen.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/iv_blurred_album_art"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#80000000"
+        android:orientation="vertical">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <include layout="@layout/status_bar" />
+        </FrameLayout>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <code.name.monkey.retromusic.views.HeightFitSquareLayout
+                android:id="@+id/albumCoverContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent">
+
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_margin="16dp"
+                    app:cardCornerRadius="@dimen/m3_card_corner_radius"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintDimensionRatio="1:1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:id="@+id/image"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scaleType="centerCrop"
+                        tools:ignore="ContentDescription,UnusedAttribute"
+                        tools:srcCompat="@tools:sample/backgrounds/scenic" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/slide"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal|bottom"
+                        android:elevation="3dp"
+                        android:fitsSystemWindows="true"
+                        android:gravity="center"
+                        android:padding="16dp"
+                        android:text="@string/swipe_to_unlock"
+                        android:textColor="?android:attr/textColorPrimary" />
+                </com.google.android.material.card.MaterialCardView>
+            </code.name.monkey.retromusic.views.HeightFitSquareLayout>
+
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:orientation="vertical"
+                tools:ignore="UselessParent">
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/playback_controls_fragment"
+                    android:name="code.name.monkey.retromusic.fragments.player.lockscreen.LockScreenControlsFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    tools:layout="@layout/fragment_lock_screen_playback_controls" />
+
+            </LinearLayout>
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+    </LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_lock_screen.xml
+++ b/app/src/main/res/layout/activity_lock_screen.xml
@@ -1,63 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <FrameLayout
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/iv_blurred_album_art"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <include layout="@layout/status_bar" />
-    </FrameLayout>
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:gravity="center_vertical"
+        android:background="#80000000"
         android:orientation="vertical"
-        tools:ignore="UselessParent">
+        android:paddingTop="24dp">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/playback_controls_fragment"
-            android:name="code.name.monkey.retromusic.fragments.player.lockscreen.LockScreenControlsFragment"
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <include layout="@layout/status_bar" />
+        </FrameLayout>
+
+        <code.name.monkey.retromusic.views.WidthFitSquareCardView
+            android:id="@+id/albumCoverContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:transitionName="@string/transition_album_art"
+            app:cardCornerRadius="24dp"
+            app:cardElevation="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/image"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop"
+                tools:srcCompat="@tools:sample/backgrounds/scenic[0]" />
+
+        </code.name.monkey.retromusic.views.WidthFitSquareCardView>
+
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:layout="@layout/fragment_lock_screen_playback_controls" />
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            tools:ignore="UselessParent">
+
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/playback_controls_fragment"
+                android:name="code.name.monkey.retromusic.fragments.player.lockscreen.LockScreenControlsFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:layout="@layout/fragment_lock_screen_playback_controls" />
+        </LinearLayout>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/slide"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:fitsSystemWindows="true"
+            android:gravity="center"
+            android:padding="16dp"
+            android:text="@string/swipe_to_unlock"
+            android:textColor="?android:attr/textColorPrimary" />
     </LinearLayout>
-
-    <code.name.monkey.retromusic.views.WidthFitSquareCardView
-        android:id="@+id/albumCoverContainer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:transitionName="@string/transition_album_art"
-        app:cardCornerRadius="24dp"
-        app:cardElevation="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/image"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            tools:srcCompat="@tools:sample/backgrounds/scenic[0]" />
-
-    </code.name.monkey.retromusic.views.WidthFitSquareCardView>
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/slide"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="0"
-        android:fitsSystemWindows="true"
-        android:gravity="center"
-        android:padding="16dp"
-        android:text="@string/swipe_to_unlock"
-        android:textColor="?android:attr/textColorPrimary" />
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
1. Fixed album art image is not clear enough and always shows the previous song's cover;
2. Change Setting -> Personalize -> LOCKSCREEN (Show album cover, Blur album cover, Fullscreen controls) only about lockscreen, without change notification style anymore;
3. Lockscreen adapt landscape mode;
4. Move lockscreen image to the top, keep look like the player's style;
5. Change some defStyleAttr default value from -1 to 0, to make Android Studio to preview;
6. Fitting more pages can display circular buttons.