### PR TITLE
Fix file popup onClick in Folders tab

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/folder/FoldersFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/folder/FoldersFragment.kt
@@ -46,6 +46,7 @@ import code.name.monkey.retromusic.extensions.textColorPrimary
 import code.name.monkey.retromusic.extensions.textColorSecondary
 import code.name.monkey.retromusic.fragments.base.AbsMainActivityFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote.openQueue
+import code.name.monkey.retromusic.helper.menu.SongMenuHelper
 import code.name.monkey.retromusic.helper.menu.SongsMenuHelper
 import code.name.monkey.retromusic.interfaces.ICallbacks
 import code.name.monkey.retromusic.interfaces.IMainActivityFragmentCallbacks
@@ -219,8 +220,9 @@ class FoldersFragment : AbsMainActivityFragment(R.layout.fragment_folder),
                                 fileComparator
                             ) { songs ->
                                 if (songs.isNotEmpty()) {
-                                    SongsMenuHelper.handleMenuClick(
-                                        requireActivity(), songs, itemId
+                                    val song = songs.first()
+                                    SongMenuHelper.handleMenuClick(
+                                        requireActivity(), song, itemId
                                     )
                                 }
                             }


### PR DESCRIPTION
Implement proper handling of click events for the following menu options:
- Go to album
- Go to artist
- Share
- Tag Editor
- Details
- Set as ringtone

<img src="https://user-images.githubusercontent.com/25669613/213942530-f831b0f5-d49a-4e88-bbfa-395480bd1096.png" width="300" />