### PR TITLE
Add required parameter for seek method in CastPlayer

### DIFF
--- a/app/src/fdroid/java/code/name/monkey/retromusic/service/CastPlayer.kt
+++ b/app/src/fdroid/java/code/name/monkey/retromusic/service/CastPlayer.kt
@@ -35,7 +35,7 @@ class CastPlayer : Playback {
 
     override fun position() = 0
 
-    override fun seek(whereto: Int) = whereto
+    override fun seek(whereto: Int, force: Boolean) = whereto
 
     override fun setVolume(vol: Float) = true
 


### PR DESCRIPTION
There is a compilation error during build fdroid variant of RetroMusicPlayer app. This PR fixes it