### PR TITLE
Fix option to shuffle all songs in Android Auto

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/service/MediaSessionCallback.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MediaSessionCallback.kt
@@ -34,6 +34,7 @@ import code.name.monkey.retromusic.util.logD
 import code.name.monkey.retromusic.util.logE
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.Arrays
 
 /**
  * Created by hemanths on 2019-08-01.
@@ -83,7 +84,7 @@ class MediaSessionCallback(
                 musicService.openQueue(songs, 0, true)
             }
             AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_SHUFFLE -> {
-                val allSongs: ArrayList<Song> = songRepository.songs() as ArrayList<Song>
+                val allSongs = songRepository.songs().toMutableList()
                 makeShuffleList(allSongs, -1)
                 musicService.openQueue(allSongs, 0, true)
             }

--- a/app/src/main/java/code/name/monkey/retromusic/service/MediaSessionCallback.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MediaSessionCallback.kt
@@ -34,7 +34,6 @@ import code.name.monkey.retromusic.util.logD
 import code.name.monkey.retromusic.util.logE
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.util.Arrays
 
 /**
  * Created by hemanths on 2019-08-01.


### PR DESCRIPTION
This aims to fix the issue reported in https://github.com/RetroMusicPlayer/RetroMusicPlayer/issues/1502

## Description
Add a fix for a cast issue when using the option to shuffle all songs in Android Auto.
Now, when getting the list of songs from repository, it calls `.toMutableList()` directly instead of casting to an ArrayList.

## Testing notes
Tested using the same device and app versions as the ones described in the bug reported mentioned at the beginning. 