### PR TITLE
MusicService: Catch IllegalArgumentException

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
@@ -1058,35 +1058,38 @@ class MusicService : MediaBrowserServiceCompat(),
             if (isBlurredAlbumArt) {
                 request.transform(BlurTransformation.Builder(this@MusicService).build())
             }
-            request.into(object :
-                CustomTarget<Bitmap?>(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL) {
-                override fun onLoadFailed(errorDrawable: Drawable?) {
-                    super.onLoadFailed(errorDrawable)
-                    metaData.putBitmap(
-                        MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
-                        BitmapFactory.decodeResource(
-                            resources,
-                            R.drawable.default_audio_art
+            try {
+                request.into(object :
+                    CustomTarget<Bitmap?>(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL) {
+                    override fun onLoadFailed(errorDrawable: Drawable?) {
+                        super.onLoadFailed(errorDrawable)
+                        metaData.putBitmap(
+                            MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
+                            BitmapFactory.decodeResource(
+                                resources,
+                                R.drawable.default_audio_art
+                            )
                         )
-                    )
-                    mediaSession?.setMetadata(metaData.build())
-                    onCompletion()
-                }
-
-                override fun onResourceReady(
-                    resource: Bitmap,
-                    transition: Transition<in Bitmap?>?,
-                ) {
-                    metaData.putBitmap(
-                        MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
-                        resource
-                    )
-                    mediaSession?.setMetadata(metaData.build())
-                    onCompletion()
-                }
-
-                override fun onLoadCleared(placeholder: Drawable?) {}
-            })
+                        mediaSession?.setMetadata(metaData.build())
+                        onCompletion()
+                    }
+    
+                    override fun onResourceReady(
+                        resource: Bitmap,
+                        transition: Transition<in Bitmap?>?,
+                    ) {
+                        metaData.putBitmap(
+                            MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
+                            resource
+                        )
+                        mediaSession?.setMetadata(metaData.build())
+                        onCompletion()
+                    }
+    
+                    override fun onLoadCleared(placeholder: Drawable?) {}
+                })
+            } catch (e: IllegalArgumentException) {
+            }
         } else {
             mediaSession?.setMetadata(metaData.build())
             onCompletion()


### PR DESCRIPTION
* On some devices, every time after phone reboots, fatal IllegalArgumentException occurs in RetroMusicPlayer due to "Volume external_primary not found"

* This commit adds try-catch statemen to stop RetroMusicPlayer from fatally crashing

Log:
09-29 07:31:49.570  4365  4365 E AndroidRuntime: FATAL EXCEPTION: main 09-29 07:31:49.570  4365  4365 E AndroidRuntime: Process: code.name.monkey.retromusic, PID: 4365 09-29 07:31:49.570  4365  4365 E AndroidRuntime: java.lang.IllegalArgumentException: Volume external_primary not found 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:172) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.content.ContentProviderProxy.query(ContentProviderNative.java:481) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.content.ContentResolver.query(ContentResolver.java:1219) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.content.ContentResolver.query(ContentResolver.java:1151) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.content.ContentResolver.query(ContentResolver.java:1107) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at code.name.monkey.retromusic.repository.c.g(SongRepository.kt:312) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at code.name.monkey.retromusic.repository.c.h(SongRepository.kt:14) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at code.name.monkey.retromusic.repository.c.c(SongRepository.kt:8) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at code.name.monkey.retromusic.service.MusicService.g(MusicService.kt:1069) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at c1.e$d$a.onLoadChildren(MediaBrowserServiceCompat.java:20) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.service.media.MediaBrowserService.performLoadChildren(MediaBrowserService.java:753) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.service.media.MediaBrowserService.addSubscription(MediaBrowserService.java:683) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.service.media.MediaBrowserService.-$$Nest$maddSubscription(Unknown Source:0) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.service.media.MediaBrowserService$ServiceBinder$3.run(MediaBrowserService.java:333) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:942) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7975) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 09-29 07:31:49.570  4365  4365 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:942)

Change-Id: Id5a3a6b562b696b57ced1c88a9de4f8a42a698d2