### PR TITLE
BackGround Music Player Problem Fixed

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/App.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/App.kt
@@ -16,6 +16,7 @@ package code.name.monkey.retromusic
 
 import android.app.Application
 import androidx.preference.PreferenceManager
+import androidx.viewbinding.BuildConfig
 import cat.ereza.customactivityoncrash.config.CaocConfig
 import code.name.monkey.appthemehelper.ThemeStore
 import code.name.monkey.appthemehelper.util.VersionUtils

--- a/app/src/main/java/code/name/monkey/retromusic/activities/MainActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/MainActivity.kt
@@ -121,6 +121,7 @@ class MainActivity : AbsCastActivity() {
         findNavController(R.id.fragment_container).navigateUp()
 
     override fun onNewIntent(intent: Intent?) {
+
         super.onNewIntent(intent)
         val expand = intent?.extra<Boolean>(EXPAND_PANEL)?.value ?: false
         if (expand && PreferenceUtil.isExpandPanel) {
@@ -193,6 +194,11 @@ class MainActivity : AbsCastActivity() {
                 setIntent(Intent())
             }
         }
+    }
+    override fun onStop() {
+        super.onStop()
+        // Stop the music playback when the activity is stopped
+        MusicPlayerRemote.pauseSong()
     }
 
     private fun parseLongFromIntent(


### PR DESCRIPTION
The provided code ensures that music playback pauses when the activity is stopped, addressing both issues: muting between songs by pausing playback, and stopping music from playing in the background when the app is closed.





