### PR TITLE
Fix bottom sheet bug

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
@@ -522,7 +522,7 @@ abstract class AbsSlidingMusicPanelActivity : AbsMusicServiceActivity(),
         val heightOfBar = windowInsets.getBottomInsets() + dip(R.dimen.mini_player_height)
         val heightOfBarWithTabs = heightOfBar + dip(R.dimen.bottom_nav_height)
         if (hide) {
-            bottomSheetBehavior.peekHeight = -windowInsets.getBottomInsets()
+            bottomSheetBehavior.peekHeight = (-windowInsets.getBottomInsets()).coerceAtLeast(0)
             bottomSheetBehavior.state = STATE_COLLAPSED
             libraryViewModel.setFabMargin(
                 this,


### PR DESCRIPTION
This fixes a bug where the bottom sheet gets "stuck" in its expanded state when it should be hidden, staying in front of the content and making user interaction impossible.