### PR TITLE
Fix sleep timer crash on Android 14+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ android {
     }
     lint {
         abortOnError true
-        warning 'ImpliedQuantity', 'Instantiatable', 'MissingQuantity', 'MissingTranslation'
+        warning 'ImpliedQuantity', 'Instantiatable', 'MissingQuantity', 'MissingTranslation', 'StringFormatInvalid'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission
+        android:name="android.permission.SCHEDULE_EXACT_ALARM"
+        tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission

--- a/app/src/main/java/code/name/monkey/retromusic/activities/PermissionActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/PermissionActivity.kt
@@ -15,6 +15,7 @@
 package code.name.monkey.retromusic.activities
 
 import android.Manifest.permission.BLUETOOTH_CONNECT
+import android.app.AlarmManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
@@ -24,6 +25,7 @@ import android.provider.Settings
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
+import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.core.text.parseAsHtml
 import androidx.core.view.isVisible
@@ -66,6 +68,11 @@ class PermissionActivity : AbsMusicServiceActivity() {
                     arrayOf(BLUETOOTH_CONNECT),
                     BLUETOOTH_PERMISSION_REQUEST
                 )
+            }
+            binding.alarmPermission.show()
+            binding.alarmPermission.setButtonClick {
+                val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                startActivity(intent)
             }
         } else {
             binding.audioPermission.setNumber("2")
@@ -124,6 +131,11 @@ class PermissionActivity : AbsMusicServiceActivity() {
                 binding.bluetoothPermission.checkImage.imageTintList =
                     ColorStateList.valueOf(accentColor())
             }
+            if (hasAlarmPermission()) {
+                binding.alarmPermission.checkImage.isVisible = true
+                binding.alarmPermission.checkImage.imageTintList =
+                    ColorStateList.valueOf(accentColor())
+            }
         }
     }
 
@@ -142,5 +154,10 @@ class PermissionActivity : AbsMusicServiceActivity() {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun hasAudioPermission(): Boolean {
         return Settings.System.canWrite(this)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun hasAlarmPermission(): Boolean {
+        return getSystemService<AlarmManager>()?.canScheduleExactAlarms() == true
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/dialogs/SleepTimerDialog.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/dialogs/SleepTimerDialog.kt
@@ -19,9 +19,11 @@ import android.app.Dialog
 import android.app.PendingIntent
 import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.os.SystemClock
+import android.provider.Settings
 import android.widget.CheckBox
 import android.widget.SeekBar
 import android.widget.TextView
@@ -129,17 +131,27 @@ class SleepTimerDialog : DialogFragment() {
                         SystemClock.elapsedRealtime() + minutes * 60 * 1000
                     PreferenceUtil.nextSleepTimerElapsedRealTime = nextSleepTimerElapsedTime.toInt()
                     val am = requireContext().getSystemService<AlarmManager>()
-                    am?.setExact(
-                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                        nextSleepTimerElapsedTime,
-                        pi
-                    )
 
-                    Toast.makeText(
-                        requireContext(),
-                        requireContext().resources.getString(R.string.sleep_timer_set, minutes),
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    if (VersionUtils.hasS() && am?.canScheduleExactAlarms() != true) {
+                        Toast.makeText(
+                            requireContext(),
+                            requireContext().resources.getString(R.string.sleep_timer_no_permission),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                        startActivity(intent)
+                    } else {
+                        am?.setExact(
+                           AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                           nextSleepTimerElapsedTime,
+                           pi
+                       )
+                        Toast.makeText(
+                            requireContext(),
+                            requireContext().resources.getString(R.string.sleep_timer_set, minutes),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
                 }
             }
             setView(binding.root)

--- a/app/src/main/res/layout/activity_permission.xml
+++ b/app/src/main/res/layout/activity_permission.xml
@@ -78,6 +78,19 @@
                 app:permissionTitleNumber="3"
                 app:permissionTitleSubTitle="@string/ringtone_summary"
                 tools:visibility="visible" />
+
+            <code.name.monkey.retromusic.views.PermissionItem
+                android:id="@+id/alarm_permission"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="@integer/permission_layout_weight"
+                android:visibility="gone"
+                app:permissionButtonTitle="@string/grant_access"
+                app:permissionIcon="@drawable/ic_phonelink_ring"
+                app:permissionTitle="@string/permission_alarm_title"
+                app:permissionTitleNumber="4"
+                app:permissionTitleSubTitle="@string/permission_alarm_summary"
+                tools:visibility="visible" />
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,8 @@
     <string name="retro_music_pro">Retro Music Pro</string>
     <string name="ringtone_summary">The app needs permission to access your device settings in order to set music as Ringtone</string>
     <string name="ringtone_title">Ringtone (Optional)</string>
+    <string name="permission_alarm_summary">The app needs permission to schedule exact alarms to set sleep timers</string>
+    <string name="permission_alarm_title">Alarm (Optional)</string>
     <string name="saf_delete_failed">File delete failed: %s</string>
     <!-- SAF -->
     <string name="saf_error_uri">Can\'t get SAF URI</string>
@@ -563,4 +565,5 @@
     <string name="you_will_be_forwarded_to_the_issue_tracker_website">You will be forwarded to the issue tracker website.</string>
     <string name="your_account_data_is_only_used_for_authentication">Your account data is only used for authentication.</string>
     <string name="could_not_write_tags_to_file">Could not write tags to the music file!</string>
+    <string name="sleep_timer_no_permission">No permission to schedule alarms, please allow Retro Music.</string>
 </resources>


### PR DESCRIPTION
As already discussed in other issues Android 14 requires an explicit permission to schedule alarms.
This PR adds the request to the permissions page, and prevents a crash informing the user.

Fixes #1670 
Fixes #1601 
Fixes #1593
Fixes #1658
Fixes #1632