### PR TITLE
Load data in parallel to improve startup time

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
@@ -32,6 +32,8 @@ import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.logD
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -58,14 +60,18 @@ class LibraryViewModel(
         loadLibraryContent()
     }
 
-    private fun loadLibraryContent() = viewModelScope.launch(IO) {
-        fetchHomeSections()
-        fetchSuggestions()
-        fetchSongs()
-        fetchAlbums()
-        fetchArtists()
-        fetchGenres()
-        fetchPlaylists()
+    private fun loadLibraryContent() {
+        viewModelScope.launch(IO) {
+            fetchHomeSections()
+            awaitAll(
+                async { fetchSuggestions() },
+                async { fetchSongs() },
+                async { fetchAlbums() },
+                async { fetchArtists() },
+                async { fetchGenres() },
+                async { fetchPlaylists() },
+            )
+        }
     }
 
     fun getSearchResult(): LiveData<List<Any>> = searchResults
@@ -333,8 +339,12 @@ class LibraryViewModel(
                     createPlaylist(PlaylistEntity(playlistName = playlistName))
                 insertSongs(songs.map { it.toSongEntity(playlistId) })
                 withContext(Main) {
-                    context.showToast(context.getString(R.string.playlist_created_sucessfully,
-                        playlistName))
+                    context.showToast(
+                        context.getString(
+                            R.string.playlist_created_sucessfully,
+                            playlistName
+                        )
+                    )
                 }
             } else {
                 val playlist = playlists.firstOrNull()
@@ -350,7 +360,9 @@ class LibraryViewModel(
                     context.getString(
                         R.string.added_song_count_to_playlist,
                         songs.size,
-                        playlistName))
+                        playlistName
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
Particularly when starting with the playlist page the app startup is noticeably slower because playlist were fetched last. This PR fetches all tabs in parallel, which improves the average startup time.
I wasn't able to see a delay on the other tabs