### PR TITLE
Keep shuffle status when selecting song

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
@@ -216,7 +216,7 @@ open class SongAdapter(
             if (isInQuickSelectMode) {
                 toggleChecked(layoutPosition)
             } else {
-                MusicPlayerRemote.openQueue(dataSet, layoutPosition, true)
+                MusicPlayerRemote.openQueueKeepShuffleMode(dataSet, layoutPosition, true)
             }
         }
 

--- a/app/src/main/java/code/name/monkey/retromusic/helper/MusicPlayerRemote.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/helper/MusicPlayerRemote.kt
@@ -211,15 +211,7 @@ object MusicPlayerRemote : KoinComponent {
      */
     @JvmStatic
     fun openQueue(queue: List<Song>, startPosition: Int, startPlaying: Boolean) {
-        if (!tryToHandleOpenPlayingQueue(
-                queue,
-                startPosition,
-                startPlaying
-            ) && musicService != null
-        ) {
-            musicService?.openQueue(queue, startPosition, startPlaying)
-            setShuffleMode(MusicService.SHUFFLE_MODE_NONE)
-        }
+        doOpenQueue(queue, startPosition, startPlaying, MusicService.SHUFFLE_MODE_NONE)
     }
 
     @JvmStatic
@@ -229,6 +221,15 @@ object MusicPlayerRemote : KoinComponent {
             startPosition = Random().nextInt(queue.size)
         }
 
+        doOpenQueue(queue, startPosition, startPlaying, MusicService.SHUFFLE_MODE_SHUFFLE)
+    }
+
+    @JvmStatic
+    fun openQueueKeepShuffleMode(queue: List<Song>, startPosition: Int, startPlaying: Boolean) {
+        doOpenQueue(queue, startPosition, startPlaying, shuffleMode)
+    }
+
+    private fun doOpenQueue(queue: List<Song>, startPosition: Int, startPlaying: Boolean, shuffleMode: Int) {
         if (!tryToHandleOpenPlayingQueue(
                 queue,
                 startPosition,
@@ -236,7 +237,7 @@ object MusicPlayerRemote : KoinComponent {
             ) && musicService != null
         ) {
             musicService?.openQueue(queue, startPosition, startPlaying)
-            setShuffleMode(MusicService.SHUFFLE_MODE_SHUFFLE)
+            setShuffleMode(shuffleMode)
         }
     }
 


### PR DESCRIPTION
As the title says, this PR changes the behavior when clicking on a song (in an album / playlist etc.). If the queue is shuffled, the new queue will also be shuffled, keeping the status.
Prior, I had to constantly re-enable the shuffle mode which was a bit annoying