### PR TITLE
Do not use prepareAsync when player may be used in callback

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/service/LocalPlayback.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/LocalPlayback.kt
@@ -140,7 +140,7 @@ abstract class LocalPlayback(val context: Context) : Playback, MediaPlayer.OnErr
                 player.setOnPreparedListener(null)
                 completion(true)
             }
-            player.prepareAsync()
+            player.prepare()
         } catch (e: Exception) {
             completion(false)
             e.printStackTrace()


### PR DESCRIPTION
Fixes #1575 
This caused unpredictable failing of the widget play buttons, especially after reboot / after the app was killed by the OS because the player was not prepared in time