### PR TITLE
Fix navigation in landscape mode

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
@@ -500,8 +500,9 @@ abstract class AbsSlidingMusicPanelActivity : AbsMusicServiceActivity(),
             )
             return
         }
+        val isBottomNavView = (navigationView is BottomNavigationView)
         if (visible xor navigationView.isVisible) {
-            val mAnimate = animate && bottomSheetBehavior.state == STATE_COLLAPSED
+            val mAnimate = animate && isBottomNavView && bottomSheetBehavior.state == STATE_COLLAPSED
             if (mAnimate) {
                 if (visible) {
                     binding.navigationView.bringToFront()
@@ -511,7 +512,7 @@ abstract class AbsSlidingMusicPanelActivity : AbsMusicServiceActivity(),
                 }
             } else {
                 binding.navigationView.isVisible = visible
-                if (visible && bottomSheetBehavior.state != STATE_EXPANDED) {
+                if (visible && isBottomNavView && bottomSheetBehavior.state != STATE_EXPANDED) {
                     binding.navigationView.bringToFront()
                 }
             }


### PR DESCRIPTION
The NavigationRailView displayed in landscape mode is hidden when navigating to other fragments (okay, expected behavior), however, when returning to the main screen it does not appear again, making navigation impossible. This solves it.