### PR TITLE
Create releases for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: GitHub Release CI
+
+on:
+  push:
+    tags: [ '*' ]
+
+env:
+  SIGNING_KEYSTORE_GITHUB: ${{ secrets.SIGNING_KEYSTORE_GITHUB }}
+  SIGNING_PROPERTIES_GITHUB: ${{ secrets.SIGNING_PROPERTIES_GITHUB }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Setup Signing
+        run: ./ci_signing_setup.sh
+      - name: Build
+        run: ./gradlew app:assemble
+      - name: Github Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+            app/build/outputs/apk/normal/release/app-normal-release.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,26 +21,26 @@ android {
         buildConfigField("String", "GOOGLE_PLAY_LICENSING_KEY", "\"${getProperty(getProperties('../public.properties'), 'GOOGLE_PLAY_LICENSE_KEY')}\"")
     }
     def signingProperties = getProperties('retro.properties')
-    def releaseSigning
+    def theSigningConfig
     if (signingProperties != null) {
-        releaseSigning = signingConfigs.create("release") {
+        theSigningConfig = signingConfigs.create("release") {
             storeFile file(getProperty(signingProperties, 'storeFile'))
             keyAlias getProperty(signingProperties, 'keyAlias')
             storePassword getProperty(signingProperties, 'storePassword')
             keyPassword getProperty(signingProperties, 'keyPassword')
         }
     } else {
-        releaseSigning = signingConfigs.debug
+        theSigningConfig = signingConfigs.debug
     }
     buildTypes {
         release {
             shrinkResources true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig releaseSigning
+            signingConfig theSigningConfig
         }
         debug {
-            signingConfig releaseSigning
+            signingConfig theSigningConfig
             applicationIdSuffix '.debug'
             versionNameSuffix ' DEBUG'
         }

--- a/ci_signing_setup.sh
+++ b/ci_signing_setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+decode_env_to_file() {
+  local env_var="${1}"
+  local dest_file="${2}"
+  if [[ -n "${!env_var}" ]]; then
+    if [[ ! -f "${dest_file}" ]]; then
+      echo "${!env_var}" | base64 --decode >"${dest_file}"
+      echo "Success: Written to ${dest_file}"
+    else
+      echo "Warning: File ${dest_file} already exists, not overwritten."
+    fi
+  else
+    echo "Warning: Environment variable ${env_var} is empty or not set, no action taken."
+  fi
+}
+
+decode_env_to_file "SIGNING_KEYSTORE_GITHUB" "retro.keystore"
+decode_env_to_file "SIGNING_PROPERTIES_GITHUB" "retro.properties"


### PR DESCRIPTION
Hi @h4h13 ,

I noticed that there are no Github releases for the last two FDroid releases, so I thought it would be useful to create them automatically for every tag. This new workflow does exactly this, you can see an example here: https://github.com/tomaThomas/RetroMusicPlayer/releases

However, signing the apk requires the keystore and properties. Those are required as base64 encoded secrets. In my fork, I created an environment that only has access to tags with the pattern `v*`, and two secrets:

- `SIGNING_KEYSTORE_GITHUB`: The keystore itself, e.g. encoded with `base64 -w 0 <keystore file>`
- `SIGNING_PROPERTIES_GITHUB`: The base64 encoded properties file with `storeFile=../retro.keystore`, e.g.
```
storeFile=../retro.keystore
keyAlias=retro
storePassword=password
keyPassword=password
```

What do you think about this? Do you want to put your key on Github? Should we create a new one only used for Github releases?
You could also add required reviewers to prevent the workflow from running and exposing the secrets by malicious code