### PR TITLE
Fix: Playback Settings won't display the Slider minimum values when it's open.

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/dialogs/PlaybackSpeedDialog.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/dialogs/PlaybackSpeedDialog.kt
@@ -17,6 +17,8 @@ class PlaybackSpeedDialog : DialogFragment() {
         val binding = DialogPlaybackSpeedBinding.inflate(layoutInflater)
         binding.playbackSpeedSlider.accent()
         binding.playbackPitchSlider.accent()
+        PreferenceUtil.playbackSpeed.toString().also { binding.speedValue.text = it }
+        PreferenceUtil.playbackPitch.toString().also { binding.pitchValue.text = it }
         binding.playbackSpeedSlider.addOnChangeListener(Slider.OnChangeListener { _, value, _ ->
             binding.speedValue.text = "$value"
         })


### PR DESCRIPTION
When set the Playback Speed or the Pitch Slider to its minimum value and we save it, when we reopen the playback settings screen, the current text lables are invisible. 

To fix it, we just need to bind the current Playback Speed or the Pitch values to the text.value on its "onCreate" lifecycle.

This is a video demonstration for a better understanding:
https://www.youtube.com/shorts/IbD2lGxZqhE