### PR TITLE
Add "/0/Android" to the default blacklist folders for privacy matters.

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/providers/BlacklistStore.java
+++ b/app/src/main/java/code/name/monkey/retromusic/providers/BlacklistStore.java
@@ -51,6 +51,7 @@ public class BlacklistStore extends SQLiteOpenHelper {
       sInstance = new BlacklistStore(context.getApplicationContext());
       if (!PreferenceUtil.INSTANCE.isInitializedBlacklist()) {
         // blacklisted by default
+        sInstance.addPathImpl(new File(Environment.getExternalStorageDirectory(), "Android"));
         sInstance.addPathImpl(
             getExternalStoragePublicDirectory(Environment.DIRECTORY_ALARMS));
         sInstance.addPathImpl(


### PR DESCRIPTION
This will exclude the Android (/storage/emulated/0/Android) folder from getting scanned by the Retro Music player to prevent the player to play the user's personal audios from other apps through the default categories:  "CategoryInfo.Category.Songs" tab.
But, the user will still be able to remove it from the blacklist folders manually by directly accessing: Setting/Other/Blacklist

![Screenshot_20250119-153138](https://github.com/user-attachments/assets/6941f2d4-9c0a-4a79-ab19-f74c4fe2cfad)

