### PR TITLE
Fix: Handle empty folder in ScanPath() to avoid stuck scan screen

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/folder/FoldersFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/folder/FoldersFragment.kt
@@ -456,6 +456,12 @@ class FoldersFragment : AbsMainActivityFragment(R.layout.fragment_folder),
 
         if (toBeScanned.isEmpty()) {
 
+            scanViewModel.notifyScanFinishedSuccessfully(
+                getString(
+                    R.string.scan_complete,
+                    0
+                )
+            )
             return
         }
 


### PR DESCRIPTION
**Issue**
When scanning a folder with no audio files, the scan screen would stay stuck with no feedback.

**Fix**
Added a check in `ScanPath()` to detect empty folders and show the "Scan complete (0)" message, returning to the folder view.

**Tested on**
- Nothing Phone 2A, versionCode 10640, versionName 6.4.0
