### PR TITLE
Fix long-press seek functionality for forward/backward buttons #1843

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/MusicSeekSkipTouchListener.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/MusicSeekSkipTouchListener.kt
@@ -20,6 +20,7 @@ class MusicSeekSkipTouchListener(val activity: FragmentActivity, val next: Boole
     private var job: Job? = null
     private var counter = 0
     private var wasSeeking = false
+    private var initialPosition = 0
 
     private var startX = 0f
     private var startY = 0f
@@ -32,17 +33,20 @@ class MusicSeekSkipTouchListener(val activity: FragmentActivity, val next: Boole
             MotionEvent.ACTION_DOWN -> {
                 startX = event.x
                 startY = event.y
+                initialPosition = MusicPlayerRemote.songProgressMillis
                 job = activity.lifecycleScope.launch(Dispatchers.Default) {
                     counter = 0
                     while (isActive) {
                         delay(500)
                         wasSeeking = true
-                        var seekingDuration = MusicPlayerRemote.songProgressMillis
+                        var seekingDuration = initialPosition
                         if (next) {
                             seekingDuration += 5000 * (counter.floorDiv(2) + 1)
                         } else {
                             seekingDuration -= 5000 * (counter.floorDiv(2) + 1)
                         }
+                        // Ensure we don't seek to negative positions
+                        seekingDuration = seekingDuration.coerceAtLeast(0)
                         withContext(Dispatchers.Main) {
                             MusicPlayerRemote.seekTo(seekingDuration)
                         }


### PR DESCRIPTION
fixes #1843 
When long-pressing the forward (⏩) or backward (⏪) buttons during song playback, the app incorrectly jumps back to 00:00 and then seeks to the intended position, instead of seeking directly from the current playback position.

Current Behavior:-
Long-press forward: Song jumps to 00:00, then moves to 00:05
Long-press backward: Song resets to 00:00 instead of seeking backward
Single press: Works correctly (changes tracks)


Expected Behavior:-
Long-press forward: Seek +5 seconds from the current position
Long-press backward: Seek -5 seconds from the current position (minimum 00:00)