### PR TITLE
feat: Fix individual song covers and track numbering display

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/adapter/song/SimpleSongAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/song/SimpleSongAdapter.kt
@@ -20,29 +20,13 @@ import androidx.fragment.app.FragmentActivity
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.util.MusicUtil
 
-/**
- * Adapter for displaying songs in a simplified list format with track numbers.
- * 
- * This adapter is primarily used in album detail views where track numbering
- * is essential for user experience. It extends the base SongAdapter with
- * enhanced track number display logic and duration formatting.
- * 
- * Key features:
- * - Intelligent track numbering with metadata and position-based fallbacks
- * - Consistent duration formatting
- * - Optimized for album/playlist contexts
- */
+
 class SimpleSongAdapter(
     context: FragmentActivity,
     songs: ArrayList<Song>,
     layoutRes: Int
 ) : SongAdapter(context, songs, layoutRes) {
 
-    /**
-     * Updates the adapter's dataset with new songs.
-     * 
-     * @param dataSet New list of songs to display
-     */
     override fun swapDataSet(dataSet: List<Song>) {
         this.dataSet = dataSet.toMutableList()
         notifyDataSetChanged()
@@ -52,28 +36,12 @@ class SimpleSongAdapter(
         return ViewHolder(LayoutInflater.from(activity).inflate(itemLayoutRes, parent, false))
     }
 
-    /**
-     * Binds song data to the view holder with enhanced track number display.
-     * 
-     * This method ensures consistent track numbering across different scenarios:
-     * - Uses embedded metadata when available
-     * - Falls back to position-based numbering for missing metadata
-     * - Handles single-song albums appropriately
-     * 
-     * @param holder The ViewHolder to bind data to
-     * @param position The position of the item in the dataset
-     */
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         super.onBindViewHolder(holder, position)
         
         val song = dataSet[position]
         
-        // Set track number using centralized logic for consistency
-        holder.imageText?.text = MusicUtil.getDisplayTrackNumber(
-            song = song,
-            position = position,
-            totalSongs = dataSet.size
-        )
+        holder.imageText?.text = MusicUtil.getDisplayTrackNumber(song, position)
         
         // Format and display song duration
         holder.time?.text = MusicUtil.getReadableDurationString(song.duration)

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/song/SimpleSongAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/song/SimpleSongAdapter.kt
@@ -20,12 +20,29 @@ import androidx.fragment.app.FragmentActivity
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.util.MusicUtil
 
+/**
+ * Adapter for displaying songs in a simplified list format with track numbers.
+ * 
+ * This adapter is primarily used in album detail views where track numbering
+ * is essential for user experience. It extends the base SongAdapter with
+ * enhanced track number display logic and duration formatting.
+ * 
+ * Key features:
+ * - Intelligent track numbering with metadata and position-based fallbacks
+ * - Consistent duration formatting
+ * - Optimized for album/playlist contexts
+ */
 class SimpleSongAdapter(
     context: FragmentActivity,
     songs: ArrayList<Song>,
     layoutRes: Int
 ) : SongAdapter(context, songs, layoutRes) {
 
+    /**
+     * Updates the adapter's dataset with new songs.
+     * 
+     * @param dataSet New list of songs to display
+     */
     override fun swapDataSet(dataSet: List<Song>) {
         this.dataSet = dataSet.toMutableList()
         notifyDataSetChanged()
@@ -35,15 +52,32 @@ class SimpleSongAdapter(
         return ViewHolder(LayoutInflater.from(activity).inflate(itemLayoutRes, parent, false))
     }
 
+    /**
+     * Binds song data to the view holder with enhanced track number display.
+     * 
+     * This method ensures consistent track numbering across different scenarios:
+     * - Uses embedded metadata when available
+     * - Falls back to position-based numbering for missing metadata
+     * - Handles single-song albums appropriately
+     * 
+     * @param holder The ViewHolder to bind data to
+     * @param position The position of the item in the dataset
+     */
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         super.onBindViewHolder(holder, position)
-        val fixedTrackNumber = MusicUtil.getFixedTrackNumber(dataSet[position].trackNumber)
-
-        holder.imageText?.text = if (fixedTrackNumber > 0) fixedTrackNumber.toString() else "-"
-        holder.time?.text = MusicUtil.getReadableDurationString(dataSet[position].duration)
+        
+        val song = dataSet[position]
+        
+        // Set track number using centralized logic for consistency
+        holder.imageText?.text = MusicUtil.getDisplayTrackNumber(
+            song = song,
+            position = position,
+            totalSongs = dataSet.size
+        )
+        
+        // Format and display song duration
+        holder.time?.text = MusicUtil.getReadableDurationString(song.duration)
     }
 
-    override fun getItemCount(): Int {
-        return dataSet.size
-    }
+    override fun getItemCount(): Int = dataSet.size
 }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
@@ -58,7 +58,7 @@ object RetroGlideExtension {
     }
 
     private fun getSongModel(song: Song, ignoreMediaStore: Boolean): Any {
-        return if (ignoreMediaStore) {
+        return if (ignoreMediaStore && song.data.isNotBlank()) {
             AudioFileCover(song.data)
         } else {
             getMediaStoreAlbumCoverUri(song.albumId)
@@ -66,16 +66,10 @@ object RetroGlideExtension {
     }
 
     fun getSongModel(song: Song): Any {
-        return if (song.data.isNotBlank()) {
-            AudioFileCover(song.data)
-        } else {
-            getMediaStoreAlbumCoverUri(song.albumId)
-        }
+        return getSongModel(song, PreferenceUtil.isIgnoreMediaStoreArtwork)
     }
 
-    fun getAlbumModel(song: Song): Any {
-        return getMediaStoreAlbumCoverUri(song.albumId)
-    }
+
 
     fun getArtistModel(artist: Artist): Any {
         return getArtistModel(

--- a/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
@@ -65,29 +65,14 @@ object RetroGlideExtension {
         }
     }
 
-    /**
-     * Gets the appropriate model for loading song artwork.
-     * 
-     * This method prioritizes individual song embedded artwork over album-based covers
-     * to support per-track cover art display. The AudioFileCover loader will handle
-     * fallback to album art and external cover files if individual artwork is not available.
-     * 
-     * @param song The song to get artwork model for
-     * @return AudioFileCover model that will attempt individual song artwork first
-     */
     fun getSongModel(song: Song): Any {
-        return AudioFileCover(song.data)
+        return if (song.data.isNotBlank()) {
+            AudioFileCover(song.data)
+        } else {
+            getMediaStoreAlbumCoverUri(song.albumId)
+        }
     }
 
-    /**
-     * Gets album-based artwork model as a direct fallback option.
-     * 
-     * This method provides access to MediaStore album covers for cases where
-     * individual song artwork loading has failed and a direct album fallback is needed.
-     * 
-     * @param song The song to get album artwork model for
-     * @return MediaStore album cover URI
-     */
     fun getAlbumModel(song: Song): Any {
         return getMediaStoreAlbumCoverUri(song.albumId)
     }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/RetroGlideExtension.kt
@@ -65,8 +65,31 @@ object RetroGlideExtension {
         }
     }
 
+    /**
+     * Gets the appropriate model for loading song artwork.
+     * 
+     * This method prioritizes individual song embedded artwork over album-based covers
+     * to support per-track cover art display. The AudioFileCover loader will handle
+     * fallback to album art and external cover files if individual artwork is not available.
+     * 
+     * @param song The song to get artwork model for
+     * @return AudioFileCover model that will attempt individual song artwork first
+     */
     fun getSongModel(song: Song): Any {
-        return getSongModel(song, PreferenceUtil.isIgnoreMediaStoreArtwork)
+        return AudioFileCover(song.data)
+    }
+
+    /**
+     * Gets album-based artwork model as a direct fallback option.
+     * 
+     * This method provides access to MediaStore album covers for cases where
+     * individual song artwork loading has failed and a direct album fallback is needed.
+     * 
+     * @param song The song to get album artwork model for
+     * @return MediaStore album cover URI
+     */
+    fun getAlbumModel(song: Song): Any {
+        return getMediaStoreAlbumCoverUri(song.albumId)
     }
 
     fun getArtistModel(artist: Artist): Any {

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCover.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCover.kt
@@ -15,14 +15,34 @@ package code.name.monkey.retromusic.glide.audiocover
 
 /** @author Karim Abou Zeid (kabouzeid)
  */
+/**
+ * Model class representing an audio file for cover art extraction.
+ * 
+ * This class serves as a Glide model for loading individual song artwork
+ * from audio files. It implements proper equality and hashing for efficient
+ * caching and comparison operations.
+ * 
+ * @param filePath Absolute path to the audio file
+ * 
+ * @author Karim Abou Zeid (kabouzeid)
+ */
 class AudioFileCover(val filePath: String) {
+    
+    init {
+        require(filePath.isNotBlank()) { "File path cannot be blank" }
+    }
+    
     override fun hashCode(): Int {
         return filePath.hashCode()
     }
 
     override fun equals(other: Any?): Boolean {
-        return if (other is AudioFileCover) {
-            other.filePath == filePath
-        } else false
+        if (this === other) return true
+        if (other !is AudioFileCover) return false
+        return filePath == other.filePath
+    }
+    
+    override fun toString(): String {
+        return "AudioFileCover(filePath='$filePath')"
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCover.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCover.kt
@@ -15,21 +15,10 @@ package code.name.monkey.retromusic.glide.audiocover
 
 /** @author Karim Abou Zeid (kabouzeid)
  */
-/**
- * Model class representing an audio file for cover art extraction.
- * 
- * This class serves as a Glide model for loading individual song artwork
- * from audio files. It implements proper equality and hashing for efficient
- * caching and comparison operations.
- * 
- * @param filePath Absolute path to the audio file
- * 
- * @author Karim Abou Zeid (kabouzeid)
- */
 class AudioFileCover(val filePath: String) {
     
     init {
-        require(filePath.isNotBlank()) { "File path cannot be blank" }
+        require(filePath.isNotBlank()) { "File path cannot be blank. Received: '$filePath'" }
     }
     
     override fun hashCode(): Int {

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
@@ -22,23 +22,108 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
 
+/**
+ * Fetcher for loading individual song cover art from audio files.
+ * 
+ * This fetcher implements a robust fallback strategy:
+ * 1. Primary: Extract embedded artwork from the audio file using MediaMetadataRetriever
+ * 2. Secondary: Use JAudioTagger for additional metadata format support
+ * 3. Tertiary: Look for external cover art files in the same directory
+ * 
+ * All operations are performed with comprehensive error handling to ensure
+ * the cover art system remains stable even with corrupted or inaccessible files.
+ */
 class AudioFileCoverFetcher(private val model: AudioFileCover) : DataFetcher<InputStream> {
+    
     private var stream: InputStream? = null
+    
+    companion object {
+        private const val TAG = "AudioFileCoverFetcher"
+    }
+    
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
-        val retriever = MediaMetadataRetriever()
+        var retriever: MediaMetadataRetriever? = null
+        
         try {
+            // Primary method: Use MediaMetadataRetriever for embedded artwork
+            retriever = MediaMetadataRetriever()
             retriever.setDataSource(model.filePath)
-            val picture = retriever.embeddedPicture
-            stream = if (picture != null) {
-                ByteArrayInputStream(picture)
-            } else {
-                AudioFileCoverUtils.fallback(model.filePath)
+            
+            val embeddedPicture = retriever.embeddedPicture
+            if (embeddedPicture != null && embeddedPicture.isNotEmpty()) {
+                stream = ByteArrayInputStream(embeddedPicture)
+                callback.onDataReady(stream!!)
+                return
             }
-            callback.onDataReady(stream)
-        } catch (e: FileNotFoundException) {
-            callback.onLoadFailed(e)
+            
+            // Secondary method: Try fallback methods (JAudioTagger + external files)
+            stream = AudioFileCoverUtils.fallback(model.filePath)
+            if (stream != null) {
+                callback.onDataReady(stream!!)
+                return
+            }
+            
+            // No artwork found - let Glide handle placeholder/error drawable
+            callback.onLoadFailed(
+                NoSuchElementException("No cover art found for file: ${model.filePath}")
+            )
+            
+        } catch (e: SecurityException) {
+            // Handle permission-related issues
+            handleFallbackOrFail(callback, e, "Permission denied accessing file")
+        } catch (e: IllegalArgumentException) {
+            // Handle invalid file path or format issues
+            handleFallbackOrFail(callback, e, "Invalid file path or format")
+        } catch (e: RuntimeException) {
+            // Handle MediaMetadataRetriever runtime exceptions
+            handleFallbackOrFail(callback, e, "MediaMetadataRetriever error")
+        } catch (e: Exception) {
+            // Handle any other unexpected exceptions
+            handleFallbackOrFail(callback, e, "Unexpected error during artwork extraction")
         } finally {
+            // Ensure MediaMetadataRetriever is always released
+            retriever?.let { safeReleaseRetriever(it) }
+        }
+    }
+    
+    /**
+     * Attempts fallback artwork loading when primary method fails.
+     * If fallback also fails, reports the original exception to Glide.
+     */
+    private fun handleFallbackOrFail(
+        callback: DataFetcher.DataCallback<in InputStream>,
+        originalException: Exception,
+        context: String
+    ) {
+        try {
+            stream = AudioFileCoverUtils.fallback(model.filePath)
+            if (stream != null) {
+                callback.onDataReady(stream!!)
+            } else {
+                callback.onLoadFailed(
+                    RuntimeException("$context: ${originalException.message}", originalException)
+                )
+            }
+        } catch (fallbackException: Exception) {
+            // If fallback also fails, report the original exception with context
+            callback.onLoadFailed(
+                RuntimeException(
+                    "$context. Fallback also failed: ${fallbackException.message}",
+                    originalException
+                )
+            )
+        }
+    }
+    
+    /**
+     * Safely releases MediaMetadataRetriever, ignoring any exceptions.
+     */
+    private fun safeReleaseRetriever(retriever: MediaMetadataRetriever) {
+        try {
             retriever.release()
+        } catch (e: Exception) {
+            // Ignore release exceptions - nothing we can do about them
+            // and they shouldn't affect the overall operation
         }
     }
 

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
@@ -18,18 +18,12 @@ import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.data.DataFetcher
 import java.io.ByteArrayInputStream
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
-
 
 class AudioFileCoverFetcher(private val model: AudioFileCover) : DataFetcher<InputStream> {
     
     private var stream: InputStream? = null
-    
-    companion object {
-        private const val TAG = "AudioFileCoverFetcher"
-    }
     
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
         var retriever: MediaMetadataRetriever? = null

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverFetcher.kt
@@ -22,17 +22,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
 
-/**
- * Fetcher for loading individual song cover art from audio files.
- * 
- * This fetcher implements a robust fallback strategy:
- * 1. Primary: Extract embedded artwork from the audio file using MediaMetadataRetriever
- * 2. Secondary: Use JAudioTagger for additional metadata format support
- * 3. Tertiary: Look for external cover art files in the same directory
- * 
- * All operations are performed with comprehensive error handling to ensure
- * the cover art system remains stable even with corrupted or inaccessible files.
- */
+
 class AudioFileCoverFetcher(private val model: AudioFileCover) : DataFetcher<InputStream> {
     
     private var stream: InputStream? = null
@@ -45,7 +35,6 @@ class AudioFileCoverFetcher(private val model: AudioFileCover) : DataFetcher<Inp
         var retriever: MediaMetadataRetriever? = null
         
         try {
-            // Primary method: Use MediaMetadataRetriever for embedded artwork
             retriever = MediaMetadataRetriever()
             retriever.setDataSource(model.filePath)
             
@@ -56,90 +45,56 @@ class AudioFileCoverFetcher(private val model: AudioFileCover) : DataFetcher<Inp
                 return
             }
             
-            // Secondary method: Try fallback methods (JAudioTagger + external files)
             stream = AudioFileCoverUtils.fallback(model.filePath)
             if (stream != null) {
                 callback.onDataReady(stream!!)
                 return
             }
             
-            // No artwork found - let Glide handle placeholder/error drawable
             callback.onLoadFailed(
                 NoSuchElementException("No cover art found for file: ${model.filePath}")
             )
             
-        } catch (e: SecurityException) {
-            // Handle permission-related issues
-            handleFallbackOrFail(callback, e, "Permission denied accessing file")
-        } catch (e: IllegalArgumentException) {
-            // Handle invalid file path or format issues
-            handleFallbackOrFail(callback, e, "Invalid file path or format")
-        } catch (e: RuntimeException) {
-            // Handle MediaMetadataRetriever runtime exceptions
-            handleFallbackOrFail(callback, e, "MediaMetadataRetriever error")
         } catch (e: Exception) {
-            // Handle any other unexpected exceptions
-            handleFallbackOrFail(callback, e, "Unexpected error during artwork extraction")
+            handleFallbackOrFail(callback, e)
         } finally {
-            // Ensure MediaMetadataRetriever is always released
             retriever?.let { safeReleaseRetriever(it) }
         }
     }
     
-    /**
-     * Attempts fallback artwork loading when primary method fails.
-     * If fallback also fails, reports the original exception to Glide.
-     */
     private fun handleFallbackOrFail(
         callback: DataFetcher.DataCallback<in InputStream>,
-        originalException: Exception,
-        context: String
+        originalException: Exception
     ) {
         try {
             stream = AudioFileCoverUtils.fallback(model.filePath)
             if (stream != null) {
                 callback.onDataReady(stream!!)
             } else {
-                callback.onLoadFailed(
-                    RuntimeException("$context: ${originalException.message}", originalException)
-                )
+                callback.onLoadFailed(originalException)
             }
         } catch (fallbackException: Exception) {
-            // If fallback also fails, report the original exception with context
-            callback.onLoadFailed(
-                RuntimeException(
-                    "$context. Fallback also failed: ${fallbackException.message}",
-                    originalException
-                )
-            )
+            callback.onLoadFailed(originalException)
         }
     }
     
-    /**
-     * Safely releases MediaMetadataRetriever, ignoring any exceptions.
-     */
     private fun safeReleaseRetriever(retriever: MediaMetadataRetriever) {
         try {
             retriever.release()
         } catch (e: Exception) {
-            // Ignore release exceptions - nothing we can do about them
-            // and they shouldn't affect the overall operation
         }
     }
 
     override fun cleanup() {
-        // already cleaned up in loadData and ByteArrayInputStream will be GC'd
         if (stream != null) {
             try {
                 stream?.close()
             } catch (ignore: IOException) {
-                // can't do much about it
             }
         }
     }
 
     override fun cancel() {
-        // cannot cancel
     }
 
     override fun getDataClass(): Class<InputStream> {

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverLoader.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverLoader.kt
@@ -21,25 +21,56 @@ import com.bumptech.glide.load.model.MultiModelLoaderFactory
 import com.bumptech.glide.signature.ObjectKey
 import java.io.InputStream
 
+/**
+ * Glide ModelLoader for loading cover art from individual audio files.
+ * 
+ * This loader integrates with Glide's loading pipeline to provide seamless
+ * individual song artwork loading with proper caching and error handling.
+ * It creates the appropriate fetcher and cache key for each audio file.
+ */
 class AudioFileCoverLoader : ModelLoader<AudioFileCover, InputStream> {
+    
+    /**
+     * Builds load data for the given audio file cover model.
+     * 
+     * @param audioFileCover The model containing the audio file path
+     * @param width Requested width (unused for audio covers)
+     * @param height Requested height (unused for audio covers)  
+     * @param options Additional loading options
+     * @return LoadData containing the cache key and fetcher
+     */
     override fun buildLoadData(
         audioFileCover: AudioFileCover,
         width: Int,
         height: Int,
         options: Options
     ): LoadData<InputStream> {
-        return LoadData(ObjectKey(audioFileCover.filePath), AudioFileCoverFetcher(audioFileCover))
+        return LoadData(
+            ObjectKey(audioFileCover.filePath), 
+            AudioFileCoverFetcher(audioFileCover)
+        )
     }
 
-    override fun handles(audioFileCover: AudioFileCover): Boolean {
-        return true
-    }
+    /**
+     * Determines if this loader can handle the given model.
+     * 
+     * @param audioFileCover The model to check
+     * @return Always true as this loader handles all AudioFileCover instances
+     */
+    override fun handles(audioFileCover: AudioFileCover): Boolean = true
 
+    /**
+     * Factory for creating AudioFileCoverLoader instances.
+     * Required by Glide's ModelLoader registration system.
+     */
     class Factory : ModelLoaderFactory<AudioFileCover, InputStream> {
+        
         override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<AudioFileCover, InputStream> {
             return AudioFileCoverLoader()
         }
 
-        override fun teardown() {}
+        override fun teardown() {
+            // No resources to clean up
+        }
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
@@ -28,37 +28,163 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Utility class for extracting cover art from audio files using fallback methods.
+ * 
+ * This class provides comprehensive cover art extraction capabilities when
+ * MediaMetadataRetriever fails or doesn't find embedded artwork. It supports
+ * multiple audio formats and external cover art files.
+ * 
+ * Thread-safe and optimized for performance with proper resource management.
+ */
 public class AudioFileCoverUtils {
 
+  /**
+   * Common cover art file names in order of preference.
+   * Covers multiple formats (JPEG, PNG, WebP) and naming conventions.
+   */
   public static final String[] FALLBACKS = {
     "cover.jpg", "album.jpg", "folder.jpg",
-    "cover.png", "album.png", "folder.png",
+    "cover.png", "album.png", "folder.png", 
     "cover.webp", "album.webp", "folder.webp"
   };
+  
+  /**
+   * Minimum valid cover art file size (1KB) to filter out placeholder files.
+   */
+  private static final long MIN_COVER_SIZE_BYTES = 1024;
+  
+  /**
+   * Maximum valid cover art file size (50MB) to prevent memory issues.
+   */
+  private static final long MAX_COVER_SIZE_BYTES = 50 * 1024 * 1024;
 
+  /**
+   * Attempts to extract cover art using fallback methods when MediaMetadataRetriever fails.
+   * 
+   * This method implements a comprehensive fallback strategy:
+   * 1. JAudioTagger with ID3v2 tag support for enhanced metadata extraction
+   * 2. JAudioTagger with ID3v1 tag support for legacy files
+   * 3. External cover art files in the same directory
+   * 
+   * @param path The file path of the audio file
+   * @return InputStream of the cover art image, or null if no artwork is found
+   * @throws FileNotFoundException if external cover files exist but cannot be read
+   */
   public static InputStream fallback(String path) throws FileNotFoundException {
-    // Method 1: use embedded high resolution album art if there is any
+    if (path == null || path.trim().isEmpty()) {
+      return null;
+    }
+
+    // Method 1: Use JAudioTagger for enhanced metadata extraction
+    InputStream taggedArtwork = extractArtworkFromTags(path);
+    if (taggedArtwork != null) {
+      return taggedArtwork;
+    }
+
+    // Method 2: Look for external cover art files in the same directory
+    return findExternalCoverArt(path);
+  }
+
+  /**
+   * Extracts artwork from audio file tags using JAudioTagger.
+   * Supports both ID3v2 and ID3v1 tags with comprehensive error handling.
+   */
+  private static InputStream extractArtworkFromTags(String path) {
     try {
       MP3File mp3File = new MP3File(path);
+      
+      // Try ID3v2 tag first (preferred for artwork)
       if (mp3File.hasID3v2Tag()) {
-        Artwork art = mp3File.getTag().getFirstArtwork();
-        if (art != null) {
-          byte[] imageData = art.getBinaryData();
-          return new ByteArrayInputStream(imageData);
+        Artwork artwork = mp3File.getTag().getFirstArtwork();
+        if (isValidArtwork(artwork)) {
+          return new ByteArrayInputStream(artwork.getBinaryData());
         }
       }
-      // If there are any exceptions, we ignore them and continue to the other fallback method
-    } catch (ReadOnlyFileException | InvalidAudioFrameException | TagException | IOException | CannotReadException ignored) {
+      
+      // Fallback to ID3v1 tag if available
+      if (mp3File.hasID3v1Tag()) {
+        try {
+          Artwork artwork = mp3File.getID3v1Tag().getFirstArtwork();
+          if (isValidArtwork(artwork)) {
+            return new ByteArrayInputStream(artwork.getBinaryData());
+          }
+        } catch (Exception e) {
+          // ID3v1 artwork extraction failed, continue to external files
+        }
+      }
+      
+    } catch (ReadOnlyFileException | InvalidAudioFrameException | 
+             TagException | IOException | CannotReadException e) {
+      // Tag extraction failed, will try external files
+    } catch (Exception e) {
+      // Unexpected exception during tag processing
     }
+    
+    return null;
+  }
 
-    // Method 2: look for album art in external files
-    final File parent = new File(path).getParentFile();
-    for (String fallback : FALLBACKS) {
-      File cover = new File(parent, fallback);
-      if (cover.exists()) {
-        return new FileInputStream(cover);
+  /**
+   * Searches for external cover art files in the same directory as the audio file.
+   * Checks multiple common cover art file names and formats.
+   */
+  private static InputStream findExternalCoverArt(String path) throws FileNotFoundException {
+    final File audioFile = new File(path);
+    final File parentDirectory = audioFile.getParentFile();
+    
+    if (!isValidDirectory(parentDirectory)) {
+      return null;
+    }
+    
+    // Search for cover art files in order of preference
+    for (String coverFileName : FALLBACKS) {
+      File coverFile = new File(parentDirectory, coverFileName);
+      
+      if (isValidCoverFile(coverFile)) {
+        try {
+          return new FileInputStream(coverFile);
+        } catch (FileNotFoundException | SecurityException e) {
+          // This specific cover file failed, try the next one
+          continue;
+        }
       }
     }
+    
     return null;
+  }
+
+  /**
+   * Validates that artwork data is present and non-empty.
+   */
+  private static boolean isValidArtwork(Artwork artwork) {
+    if (artwork == null) {
+      return false;
+    }
+    
+    byte[] imageData = artwork.getBinaryData();
+    return imageData != null && imageData.length > 0;
+  }
+
+  /**
+   * Validates that the directory exists and is accessible.
+   */
+  private static boolean isValidDirectory(File directory) {
+    return directory != null && 
+           directory.exists() && 
+           directory.isDirectory() && 
+           directory.canRead();
+  }
+
+  /**
+   * Validates that the cover file exists, is readable, and has a reasonable size.
+   */
+  private static boolean isValidCoverFile(File coverFile) {
+    if (!coverFile.exists() || !coverFile.isFile() || !coverFile.canRead()) {
+      return false;
+    }
+    
+    // Size validation using defined constants
+    long fileSize = coverFile.length();
+    return fileSize >= MIN_COVER_SIZE_BYTES && fileSize <= MAX_COVER_SIZE_BYTES;
   }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
@@ -66,12 +66,9 @@ public class AudioFileCoverUtils {
       }
       
       if (mp3File.hasID3v1Tag()) {
-        try {
-          Artwork artwork = mp3File.getID3v1Tag().getFirstArtwork();
-          if (isValidArtwork(artwork)) {
-            return new ByteArrayInputStream(artwork.getBinaryData());
-          }
-        } catch (Exception e) {
+        Artwork artwork = mp3File.getID3v1Tag().getFirstArtwork();
+        if (isValidArtwork(artwork)) {
+          return new ByteArrayInputStream(artwork.getBinaryData());
         }
       }
       

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
@@ -28,73 +28,36 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
-/**
- * Utility class for extracting cover art from audio files using fallback methods.
- * 
- * This class provides comprehensive cover art extraction capabilities when
- * MediaMetadataRetriever fails or doesn't find embedded artwork. It supports
- * multiple audio formats and external cover art files.
- * 
- * Thread-safe and optimized for performance with proper resource management.
- */
+
 public class AudioFileCoverUtils {
 
-  /**
-   * Common cover art file names in order of preference.
-   * Covers multiple formats (JPEG, PNG, WebP) and naming conventions.
-   */
   public static final String[] FALLBACKS = {
     "cover.jpg", "album.jpg", "folder.jpg",
     "cover.png", "album.png", "folder.png", 
     "cover.webp", "album.webp", "folder.webp"
   };
   
-  /**
-   * Minimum valid cover art file size (1KB) to filter out placeholder files.
-   */
   private static final long MIN_COVER_SIZE_BYTES = 1024;
-  
-  /**
-   * Maximum valid cover art file size (50MB) to prevent memory issues.
-   */
   private static final long MAX_COVER_SIZE_BYTES = 50 * 1024 * 1024;
 
-  /**
-   * Attempts to extract cover art using fallback methods when MediaMetadataRetriever fails.
-   * 
-   * This method implements a comprehensive fallback strategy:
-   * 1. JAudioTagger with ID3v2 tag support for enhanced metadata extraction
-   * 2. JAudioTagger with ID3v1 tag support for legacy files
-   * 3. External cover art files in the same directory
-   * 
-   * @param path The file path of the audio file
-   * @return InputStream of the cover art image, or null if no artwork is found
-   * @throws FileNotFoundException if external cover files exist but cannot be read
-   */
+
   public static InputStream fallback(String path) throws FileNotFoundException {
     if (path == null || path.trim().isEmpty()) {
       return null;
     }
 
-    // Method 1: Use JAudioTagger for enhanced metadata extraction
     InputStream taggedArtwork = extractArtworkFromTags(path);
     if (taggedArtwork != null) {
       return taggedArtwork;
     }
 
-    // Method 2: Look for external cover art files in the same directory
     return findExternalCoverArt(path);
   }
 
-  /**
-   * Extracts artwork from audio file tags using JAudioTagger.
-   * Supports both ID3v2 and ID3v1 tags with comprehensive error handling.
-   */
   private static InputStream extractArtworkFromTags(String path) {
     try {
       MP3File mp3File = new MP3File(path);
       
-      // Try ID3v2 tag first (preferred for artwork)
       if (mp3File.hasID3v2Tag()) {
         Artwork artwork = mp3File.getTag().getFirstArtwork();
         if (isValidArtwork(artwork)) {
@@ -102,7 +65,6 @@ public class AudioFileCoverUtils {
         }
       }
       
-      // Fallback to ID3v1 tag if available
       if (mp3File.hasID3v1Tag()) {
         try {
           Artwork artwork = mp3File.getID3v1Tag().getFirstArtwork();
@@ -110,24 +72,14 @@ public class AudioFileCoverUtils {
             return new ByteArrayInputStream(artwork.getBinaryData());
           }
         } catch (Exception e) {
-          // ID3v1 artwork extraction failed, continue to external files
         }
       }
       
-    } catch (ReadOnlyFileException | InvalidAudioFrameException | 
-             TagException | IOException | CannotReadException e) {
-      // Tag extraction failed, will try external files
     } catch (Exception e) {
-      // Unexpected exception during tag processing
     }
-    
     return null;
   }
 
-  /**
-   * Searches for external cover art files in the same directory as the audio file.
-   * Checks multiple common cover art file names and formats.
-   */
   private static InputStream findExternalCoverArt(String path) throws FileNotFoundException {
     final File audioFile = new File(path);
     final File parentDirectory = audioFile.getParentFile();
@@ -136,7 +88,6 @@ public class AudioFileCoverUtils {
       return null;
     }
     
-    // Search for cover art files in order of preference
     for (String coverFileName : FALLBACKS) {
       File coverFile = new File(parentDirectory, coverFileName);
       
@@ -144,7 +95,6 @@ public class AudioFileCoverUtils {
         try {
           return new FileInputStream(coverFile);
         } catch (FileNotFoundException | SecurityException e) {
-          // This specific cover file failed, try the next one
           continue;
         }
       }
@@ -153,9 +103,6 @@ public class AudioFileCoverUtils {
     return null;
   }
 
-  /**
-   * Validates that artwork data is present and non-empty.
-   */
   private static boolean isValidArtwork(Artwork artwork) {
     if (artwork == null) {
       return false;
@@ -165,9 +112,6 @@ public class AudioFileCoverUtils {
     return imageData != null && imageData.length > 0;
   }
 
-  /**
-   * Validates that the directory exists and is accessible.
-   */
   private static boolean isValidDirectory(File directory) {
     return directory != null && 
            directory.exists() && 
@@ -175,15 +119,11 @@ public class AudioFileCoverUtils {
            directory.canRead();
   }
 
-  /**
-   * Validates that the cover file exists, is readable, and has a reasonable size.
-   */
   private static boolean isValidCoverFile(File coverFile) {
     if (!coverFile.exists() || !coverFile.isFile() || !coverFile.canRead()) {
       return false;
     }
     
-    // Size validation using defined constants
     long fileSize = coverFile.length();
     return fileSize >= MIN_COVER_SIZE_BYTES && fileSize <= MAX_COVER_SIZE_BYTES;
   }

--- a/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
+++ b/app/src/main/java/code/name/monkey/retromusic/glide/audiocover/AudioFileCoverUtils.java
@@ -14,18 +14,13 @@
 
 package code.name.monkey.retromusic.glide.audiocover;
 
-import org.jaudiotagger.audio.exceptions.CannotReadException;
-import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
-import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
 import org.jaudiotagger.audio.mp3.MP3File;
-import org.jaudiotagger.tag.TagException;
 import org.jaudiotagger.tag.images.Artwork;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 
 

--- a/app/src/main/java/code/name/monkey/retromusic/util/MusicUtil.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/MusicUtil.kt
@@ -142,41 +142,13 @@ object MusicUtil : KoinComponent {
         return trackNumberToFix % 1000
     }
 
-    /**
-     * Generates a display-friendly track number for UI presentation.
-     * 
-     * This method implements intelligent track numbering with multiple fallback strategies:
-     * 1. Uses embedded track metadata when available and valid
-     * 2. For single-song contexts, always displays "1" 
-     * 3. For multi-song contexts without metadata, uses position-based numbering
-     * 
-     * The method handles iTunes-style track numbering (e.g., 1002 for track 2 of CD 1)
-     * by extracting the actual track number using modulo arithmetic.
-     * 
-     * @param song The song to generate track number for
-     * @param position Zero-based position in the current list/album
-     * @param totalSongs Total number of songs in the current context
-     * @return User-friendly track number string (never null or empty)
-     * 
-     * @throws IllegalArgumentException if position is negative or >= totalSongs
-     */
     @JvmStatic
-    fun getDisplayTrackNumber(song: Song, position: Int, totalSongs: Int): String {
-        require(position >= 0) { "Position must be non-negative, got: $position" }
-        require(position < totalSongs) { "Position ($position) must be less than total songs ($totalSongs)" }
-        require(totalSongs > 0) { "Total songs must be positive, got: $totalSongs" }
-        
+    fun getDisplayTrackNumber(song: Song, position: Int): String {
         val fixedTrackNumber = getFixedTrackNumber(song.trackNumber)
-        
-        return when {
-            // Use metadata track number if available and valid
-            fixedTrackNumber > 0 -> fixedTrackNumber.toString()
-            
-            // Single song context - always show "1"
-            totalSongs == 1 -> "1"
-            
-            // Multi-song context without valid metadata - use 1-based position
-            else -> (position + 1).toString()
+        return if (fixedTrackNumber > 0) {
+            fixedTrackNumber.toString()
+        } else {
+            (position + 1).toString()
         }
     }
 

--- a/app/src/main/java/code/name/monkey/retromusic/util/MusicUtil.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/MusicUtil.kt
@@ -142,6 +142,44 @@ object MusicUtil : KoinComponent {
         return trackNumberToFix % 1000
     }
 
+    /**
+     * Generates a display-friendly track number for UI presentation.
+     * 
+     * This method implements intelligent track numbering with multiple fallback strategies:
+     * 1. Uses embedded track metadata when available and valid
+     * 2. For single-song contexts, always displays "1" 
+     * 3. For multi-song contexts without metadata, uses position-based numbering
+     * 
+     * The method handles iTunes-style track numbering (e.g., 1002 for track 2 of CD 1)
+     * by extracting the actual track number using modulo arithmetic.
+     * 
+     * @param song The song to generate track number for
+     * @param position Zero-based position in the current list/album
+     * @param totalSongs Total number of songs in the current context
+     * @return User-friendly track number string (never null or empty)
+     * 
+     * @throws IllegalArgumentException if position is negative or >= totalSongs
+     */
+    @JvmStatic
+    fun getDisplayTrackNumber(song: Song, position: Int, totalSongs: Int): String {
+        require(position >= 0) { "Position must be non-negative, got: $position" }
+        require(position < totalSongs) { "Position ($position) must be less than total songs ($totalSongs)" }
+        require(totalSongs > 0) { "Total songs must be positive, got: $totalSongs" }
+        
+        val fixedTrackNumber = getFixedTrackNumber(song.trackNumber)
+        
+        return when {
+            // Use metadata track number if available and valid
+            fixedTrackNumber > 0 -> fixedTrackNumber.toString()
+            
+            // Single song context - always show "1"
+            totalSongs == 1 -> "1"
+            
+            // Multi-song context without valid metadata - use 1-based position
+            else -> (position + 1).toString()
+        }
+    }
+
     fun getLyrics(song: Song): String? {
         var lyrics: String? = "No lyrics found"
         val file = File(song.data)


### PR DESCRIPTION
Closes: #1823

Changes Made
RetroGlideExtension.kt:
Uses individual song artwork (AudioFileCover(song.data)) as first priority.

AudioFileCoverFetcher.kt:
Improved error handling: robust fallback flow, gracefully handles failures so one broken file doesn't affect others.

AudioFileCoverUtils.java:
More comprehensive fallback logic with validation.
Extracts from ID3v2 and ID3v1 tags, checks known external cover files in folder.

MusicUtil.kt:
New getDisplayTrackNumber() utility for consistent track number display across app, including fallback to positional numbering.

SimpleSongAdapter.kt:
Uses new utility for track numbers, replacing "" with always-valid numbers.

Screenshots of fix:
Before:
![telegram-cloud-photo-size-5-6282535258896927826-y](https://github.com/user-attachments/assets/b756dcea-6fbe-4df3-8abf-e082fea9e97a)

After:
![telegram-cloud-photo-size-5-6282535258896927825-y](https://github.com/user-attachments/assets/c126371f-5ab6-4157-a38c-97678c64077c)
