### PR TITLE
feat: Implement support for multiple artist separators

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/base/AbsSlidingMusicPanelActivity.kt
@@ -34,44 +34,10 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.commit
 import androidx.navigation.fragment.NavHostFragment
 import code.name.monkey.appthemehelper.util.VersionUtils
-import code.name.monkey.retromusic.ADAPTIVE_COLOR_APP
-import code.name.monkey.retromusic.ALBUM_COVER_STYLE
-import code.name.monkey.retromusic.ALBUM_COVER_TRANSFORM
-import code.name.monkey.retromusic.CAROUSEL_EFFECT
-import code.name.monkey.retromusic.CIRCLE_PLAY_BUTTON
-import code.name.monkey.retromusic.EXTRA_SONG_INFO
-import code.name.monkey.retromusic.KEEP_SCREEN_ON
-import code.name.monkey.retromusic.LIBRARY_CATEGORIES
-import code.name.monkey.retromusic.NOW_PLAYING_SCREEN_ID
-import code.name.monkey.retromusic.R
-import code.name.monkey.retromusic.SCREEN_ON_LYRICS
-import code.name.monkey.retromusic.SWIPE_ANYWHERE_NOW_PLAYING
-import code.name.monkey.retromusic.SWIPE_DOWN_DISMISS
-import code.name.monkey.retromusic.TAB_TEXT_MODE
-import code.name.monkey.retromusic.TOGGLE_ADD_CONTROLS
-import code.name.monkey.retromusic.TOGGLE_FULL_SCREEN
-import code.name.monkey.retromusic.TOGGLE_VOLUME
+import code.name.monkey.retromusic.*
 import code.name.monkey.retromusic.activities.PermissionActivity
 import code.name.monkey.retromusic.databinding.SlidingMusicPanelLayoutBinding
-import code.name.monkey.retromusic.extensions.currentFragment
-import code.name.monkey.retromusic.extensions.darkAccentColor
-import code.name.monkey.retromusic.extensions.dip
-import code.name.monkey.retromusic.extensions.getBottomInsets
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.isColorLight
-import code.name.monkey.retromusic.extensions.isLandscape
-import code.name.monkey.retromusic.extensions.keepScreenOn
-import code.name.monkey.retromusic.extensions.maybeSetScreenOn
-import code.name.monkey.retromusic.extensions.peekHeightAnimate
-import code.name.monkey.retromusic.extensions.setLightNavigationBar
-import code.name.monkey.retromusic.extensions.setLightNavigationBarAuto
-import code.name.monkey.retromusic.extensions.setLightStatusBar
-import code.name.monkey.retromusic.extensions.setLightStatusBarAuto
-import code.name.monkey.retromusic.extensions.setNavigationBarColorPreOreo
-import code.name.monkey.retromusic.extensions.setTaskDescriptionColor
-import code.name.monkey.retromusic.extensions.show
-import code.name.monkey.retromusic.extensions.surfaceColor
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.LibraryViewModel
 import code.name.monkey.retromusic.fragments.NowPlayingScreen
 import code.name.monkey.retromusic.fragments.NowPlayingScreen.*
@@ -122,13 +88,16 @@ abstract class AbsSlidingMusicPanelActivity : AbsMusicServiceActivity(),
     var fromNotification = false
     private var windowInsets: WindowInsetsCompat? = null
     protected val libraryViewModel by viewModel<LibraryViewModel>()
-    private lateinit var bottomSheetBehavior: BottomSheetBehavior<FrameLayout>
+    
+    internal lateinit var bottomSheetBehavior: BottomSheetBehavior<FrameLayout>
+    
     private lateinit var playerFragment: AbsPlayerFragment
     private var miniPlayerFragment: MiniPlayerFragment? = null
     private var nowPlayingScreen: NowPlayingScreen? = null
     private var taskColor: Int = 0
     private var paletteColor: Int = android.graphics.Color.WHITE
-    private var navigationBarColor = 0
+    
+    protected var navigationBarColor = 0
 
     private val panelState: Int
         get() = bottomSheetBehavior.state

--- a/app/src/main/java/code/name/monkey/retromusic/activities/tageditor/SongTagEditorActivity.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/tageditor/SongTagEditorActivity.kt
@@ -35,6 +35,7 @@ import code.name.monkey.retromusic.glide.RetroGlideExtension.asBitmapPalette
 import code.name.monkey.retromusic.glide.palette.BitmapPaletteWrapper
 import code.name.monkey.retromusic.model.ArtworkInfo
 import code.name.monkey.retromusic.repository.SongRepository
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.ImageUtil
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.RetroColorUtil
@@ -73,8 +74,14 @@ class SongTagEditorActivity : AbsTagEditorActivity<ActivitySongTagEditorBinding>
         binding.songTextContainer.setTint(false)
         binding.composerContainer.setTint(false)
         binding.albumTextContainer.setTint(false)
+        
         binding.artistContainer.setTint(false)
+        val separators = ArtistSeparator.SEPARATORS.joinToString(" ")
+        binding.artistContainer.helperText = getString(R.string.artist_separator_helper_text, separators)
+
         binding.albumArtistContainer.setTint(false)
+        binding.albumArtistContainer.helperText = getString(R.string.artist_separator_helper_text, separators)
+
         binding.yearContainer.setTint(false)
         binding.genreContainer.setTint(false)
         binding.trackNumberContainer.setTint(false)
@@ -171,37 +178,39 @@ class SongTagEditorActivity : AbsTagEditorActivity<ActivitySongTagEditorBinding>
     override fun getSongUris(): List<Uri> = listOf(MusicUtil.getSongFileUri(id))
 
     override fun loadImageFromFile(selectedFile: Uri?) {
-        Glide.with(this@SongTagEditorActivity)
-            .asBitmapPalette()
-            .load(selectedFile)
-            .diskCacheStrategy(DiskCacheStrategy.NONE)
-            .skipMemoryCache(true)
-            .into(object : ImageViewTarget<BitmapPaletteWrapper>(binding.editorImage) {
-                override fun onResourceReady(
-                    resource: BitmapPaletteWrapper,
-                    transition: Transition<in BitmapPaletteWrapper>?
-                ) {
-                    RetroColorUtil.getColor(resource.palette, Color.TRANSPARENT)
-                    albumArtBitmap = resource.bitmap?.let { ImageUtil.resizeBitmap(it, 2048) }
-                    setImageBitmap(
-                        albumArtBitmap,
-                        RetroColorUtil.getColor(
-                            resource.palette,
-                            defaultFooterColor()
+        if (!isDestroyed) {
+            Glide.with(this)
+                .asBitmapPalette()
+                .load(selectedFile)
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
+                .into(object : ImageViewTarget<BitmapPaletteWrapper>(binding.editorImage) {
+                    override fun onResourceReady(
+                        resource: BitmapPaletteWrapper,
+                        transition: Transition<in BitmapPaletteWrapper>?
+                    ) {
+                        RetroColorUtil.getColor(resource.palette, Color.TRANSPARENT)
+                        albumArtBitmap = resource.bitmap?.let { ImageUtil.resizeBitmap(it, 2048) }
+                        setImageBitmap(
+                            albumArtBitmap,
+                            RetroColorUtil.getColor(
+                                resource.palette,
+                                defaultFooterColor()
+                            )
                         )
-                    )
-                    deleteAlbumArt = false
-                    dataChanged()
-                    setResult(Activity.RESULT_OK)
-                }
+                        deleteAlbumArt = false
+                        dataChanged()
+                        setResult(Activity.RESULT_OK)
+                    }
 
-                override fun onLoadFailed(errorDrawable: Drawable?) {
-                    super.onLoadFailed(errorDrawable)
-                    showToast(R.string.error_load_failed, Toast.LENGTH_LONG)
-                }
+                    override fun onLoadFailed(errorDrawable: Drawable?) {
+                        super.onLoadFailed(errorDrawable)
+                        showToast(R.string.error_load_failed, Toast.LENGTH_LONG)
+                    }
 
-                override fun setResource(resource: BitmapPaletteWrapper?) {}
-            })
+                    override fun setResource(resource: BitmapPaletteWrapper?) {}
+                })
+        }
     }
 
     companion object {

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/HomeAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/HomeAdapter.kt
@@ -189,13 +189,13 @@ class HomeAdapter(private val activity: AppCompatActivity) :
     private fun linearLayoutManager() =
         LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
 
-    override fun onArtist(artistId: Long, view: View) {
+    override fun onArtist(artistName: String, view: View) {
         activity.findNavController(R.id.fragment_container).navigate(
             R.id.artistDetailsFragment,
-            bundleOf(EXTRA_ARTIST_ID to artistId),
+            bundleOf(EXTRA_ARTIST_NAME to artistName),
             null,
             FragmentNavigatorExtras(
-                view to artistId.toString()
+                view to artistName
             )
         )
     }

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/SearchAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/SearchAdapter.kt
@@ -39,6 +39,7 @@ import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
 import code.name.monkey.retromusic.model.Genre
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator 
 import code.name.monkey.retromusic.util.MusicUtil
 import com.bumptech.glide.Glide
 import java.util.*
@@ -93,7 +94,10 @@ class SearchAdapter(
                 holder.imageTextContainer?.isVisible = true
                 val album = dataSet[position] as Album
                 holder.title?.text = album.title
-                holder.text?.text = album.artistName
+                
+                val formattedArtistName = ArtistSeparator.split(album.artistName).joinToString(", ")
+                holder.text?.text = formattedArtistName
+                
                 Glide.with(activity).asDrawable().albumCoverOptions(album.safeGetFirstSong())
                     .load(RetroGlideExtension.getSongModel(album.safeGetFirstSong()))
                     .into(holder.image!!)
@@ -113,7 +117,10 @@ class SearchAdapter(
                 holder.imageTextContainer?.isVisible = true
                 val song = dataSet[position] as Song
                 holder.title?.text = song.title
-                holder.text?.text = song.albumName
+
+                val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+                holder.text?.text = formattedArtistName
+
                 Glide.with(activity).asDrawable().songCoverOptions(song)
                     .load(RetroGlideExtension.getSongModel(song)).into(holder.image!!)
             }
@@ -134,7 +141,6 @@ class SearchAdapter(
             PLAYLIST -> {
                 val playlist = dataSet[position] as PlaylistWithSongs
                 holder.title?.text = playlist.playlistEntity.playlistName
-                //holder.text?.text = MusicUtil.playlistInfoString(activity, playlist.songs)
             }
 
             ALBUM_ARTIST -> {
@@ -175,7 +181,7 @@ class SearchAdapter(
 
             when (itemViewType) {
                 ALBUM -> setImageTransitionName(activity.getString(R.string.transition_album_art))
-                ARTIST -> setImageTransitionName(activity.getString(R.string.transition_artist_image))
+                ARTIST -> setImageTransitionName((dataSet[layoutPosition] as Artist).name)
                 else -> {
                     val container = itemView.findViewById<View>(R.id.imageContainer)
                     container?.isVisible = false
@@ -196,7 +202,7 @@ class SearchAdapter(
                 ARTIST -> {
                     activity.findNavController(R.id.fragment_container).navigate(
                         R.id.artistDetailsFragment,
-                        bundleOf(EXTRA_ARTIST_ID to (item as Artist).id)
+                        bundleOf(EXTRA_ARTIST_NAME to (item as Artist).name)
                     )
                 }
 

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/SearchAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/SearchAdapter.kt
@@ -39,7 +39,7 @@ import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
 import code.name.monkey.retromusic.model.Genre
 import code.name.monkey.retromusic.model.Song
-import code.name.monkey.retromusic.util.ArtistSeparator 
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.MusicUtil
 import com.bumptech.glide.Glide
 import java.util.*
@@ -89,10 +89,12 @@ class SearchAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = dataSet[position]
         when (getItemViewType(position)) {
             ALBUM -> {
+                val album = item as Album
+                holder.setImageTransitionName(album.id.toString())
                 holder.imageTextContainer?.isVisible = true
-                val album = dataSet[position] as Album
                 holder.title?.text = album.title
                 
                 val formattedArtistName = ArtistSeparator.split(album.artistName).joinToString(", ")
@@ -103,9 +105,10 @@ class SearchAdapter(
                     .into(holder.image!!)
             }
 
-            ARTIST -> {
+            ARTIST, ALBUM_ARTIST -> { 
+                val artist = item as Artist
+                holder.setImageTransitionName(artist.name) 
                 holder.imageTextContainer?.isVisible = true
-                val artist = dataSet[position] as Artist
                 holder.title?.text = artist.name
                 holder.text?.text = MusicUtil.getArtistInfoString(activity, artist)
                 Glide.with(activity).asDrawable().artistImageOptions(artist).load(
@@ -114,8 +117,8 @@ class SearchAdapter(
             }
 
             SONG -> {
+                val song = item as Song
                 holder.imageTextContainer?.isVisible = true
-                val song = dataSet[position] as Song
                 holder.title?.text = song.title
 
                 val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
@@ -126,7 +129,7 @@ class SearchAdapter(
             }
 
             GENRE -> {
-                val genre = dataSet[position] as Genre
+                val genre = item as Genre
                 holder.title?.text = genre.name
                 holder.text?.text = String.format(
                     Locale.getDefault(),
@@ -139,22 +142,12 @@ class SearchAdapter(
             }
 
             PLAYLIST -> {
-                val playlist = dataSet[position] as PlaylistWithSongs
+                val playlist = item as PlaylistWithSongs
                 holder.title?.text = playlist.playlistEntity.playlistName
             }
 
-            ALBUM_ARTIST -> {
-                holder.imageTextContainer?.isVisible = true
-                val artist = dataSet[position] as Artist
-                holder.title?.text = artist.name
-                holder.text?.text = MusicUtil.getArtistInfoString(activity, artist)
-                Glide.with(activity).asDrawable().artistImageOptions(artist).load(
-                    RetroGlideExtension.getArtistModel(artist)
-                ).into(holder.image!!)
-            }
-
-            else -> {
-                holder.title?.text = dataSet[position].toString()
+            else -> { 
+                holder.title?.text = item.toString()
                 holder.title?.setTextColor(ThemeStore.accentColor(activity))
             }
         }
@@ -164,7 +157,7 @@ class SearchAdapter(
         return dataSet.size
     }
 
-    inner class ViewHolder(itemView: View, itemViewType: Int) : MediaEntryViewHolder(itemView) {
+    inner class ViewHolder(itemView: View, private val itemViewType: Int) : MediaEntryViewHolder(itemView) {
         init {
             itemView.setOnLongClickListener(null)
             imageTextContainer?.isInvisible = true
@@ -179,13 +172,9 @@ class SearchAdapter(
                 menu?.isVisible = false
             }
 
-            when (itemViewType) {
-                ALBUM -> setImageTransitionName(activity.getString(R.string.transition_album_art))
-                ARTIST -> setImageTransitionName((dataSet[layoutPosition] as Artist).name)
-                else -> {
-                    val container = itemView.findViewById<View>(R.id.imageContainer)
-                    container?.isVisible = false
-                }
+            if (itemViewType != ALBUM && itemViewType != ARTIST && itemViewType != ALBUM_ARTIST && itemViewType != SONG) {
+                 val container = itemView.findViewById<View>(R.id.imageContainer)
+                 container?.isVisible = false
             }
         }
 

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/artist/ArtistAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/artist/ArtistAdapter.kt
@@ -88,8 +88,8 @@ class ArtistAdapter(
         holder.itemView.isActivated = isChecked
         holder.title?.text = artist.name
         holder.text?.hide()
-        val transitionName =
-            if (albumArtistsOnly) artist.name else artist.id.toString()
+        
+        val transitionName = artist.name
         if (holder.imageContainer != null) {
             holder.imageContainer?.transitionName = transitionName
         } else {
@@ -174,7 +174,7 @@ class ArtistAdapter(
                     if (albumArtistsOnly && IAlbumArtistClickListener != null) {
                         IAlbumArtistClickListener.onAlbumArtist(artist.name, imageContainer ?: it)
                     } else {
-                        IArtistClickListener.onArtist(artist.id, imageContainer ?: it)
+                        IArtistClickListener.onArtist(artist.name, imageContainer ?: it)
                     }
                 }
             }

--- a/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
@@ -38,9 +38,7 @@ import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.helper.menu.SongMenuHelper
 import code.name.monkey.retromusic.helper.menu.SongsMenuHelper
 import code.name.monkey.retromusic.model.Song
-import code.name.monkey.retromusic.util.MusicUtil
-import code.name.monkey.retromusic.util.PreferenceUtil
-import code.name.monkey.retromusic.util.RetroUtil
+import code.name.monkey.retromusic.util.* 
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.bumptech.glide.Glide
 import me.zhanghai.android.fastscroll.PopupTextProvider
@@ -95,8 +93,11 @@ open class SongAdapter(
         holder.itemView.isActivated = isChecked
         holder.menu?.isGone = isChecked
         holder.title?.text = getSongTitle(song)
-        holder.text?.text = getSongText(song)
-        holder.text2?.text = getSongText(song)
+
+        val formattedArtistName = ArtistSeparator.split(getSongText(song)).joinToString(", ")
+        holder.text?.text = formattedArtistName
+        holder.text2?.text = getSongText2(song) 
+
         loadAlbumCover(song, holder)
         val landscape = RetroUtil.isLandscape
         if ((PreferenceUtil.songGridSize > 2 && !landscape) || (PreferenceUtil.songGridSizeLand > 5 && landscape)) {

--- a/app/src/main/java/code/name/monkey/retromusic/appwidgets/base/BaseAppWidget.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/appwidgets/base/BaseAppWidget.kt
@@ -35,6 +35,7 @@ import code.name.monkey.retromusic.service.MusicService.Companion.EXTRA_APP_WIDG
 import code.name.monkey.retromusic.service.MusicService.Companion.FAVORITE_STATE_CHANGED
 import code.name.monkey.retromusic.service.MusicService.Companion.META_CHANGED
 import code.name.monkey.retromusic.service.MusicService.Companion.PLAY_STATE_CHANGED
+import code.name.monkey.retromusic.util.ArtistSeparator 
 
 abstract class BaseAppWidget : AppWidgetProvider() {
 
@@ -121,8 +122,11 @@ abstract class BaseAppWidget : AppWidgetProvider() {
 
     protected fun getSongArtistAndAlbum(song: Song): String {
         val builder = StringBuilder()
-        builder.append(song.artistName)
-        if (song.artistName.isNotEmpty() && song.albumName.isNotEmpty()) {
+        
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        builder.append(formattedArtistName)
+        
+        if (formattedArtistName.isNotEmpty() && song.albumName.isNotEmpty()) {
             builder.append(" • ")
         }
         builder.append(song.albumName)

--- a/app/src/main/java/code/name/monkey/retromusic/auto/AutoMusicProvider.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/auto/AutoMusicProvider.kt
@@ -22,6 +22,7 @@ import code.name.monkey.retromusic.model.CategoryInfo
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.repository.*
 import code.name.monkey.retromusic.service.MusicService
+import code.name.monkey.retromusic.util.ArtistSeparator 
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
 import java.lang.ref.WeakReference
@@ -63,11 +64,12 @@ class AutoMusicProvider(
                 )
             }
             AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ALBUM -> for (album in albumsRepository.albums()) {
+                val formattedArtistName = ArtistSeparator.split(album.albumArtist ?: album.artistName).joinToString(", ")
                 mediaItems.add(
                     AutoMediaItem.with(mContext)
                         .path(mediaId, album.id)
                         .title(album.title)
-                        .subTitle(album.albumArtist ?: album.artistName)
+                        .subTitle(formattedArtistName)
                         .icon(MusicUtil.getMediaStoreAlbumCoverUri(album.id))
                         .asPlayable()
                         .build()
@@ -105,15 +107,7 @@ class AutoMusicProvider(
                 mMusicService?.get()?.playingQueue
                     ?.let {
                         for (song in it) {
-                            mediaItems.add(
-                                AutoMediaItem.with(mContext)
-                                    .asPlayable()
-                                    .path(mediaId, song.id)
-                                    .title(song.title)
-                                    .subTitle(song.artistName)
-                                    .icon(MusicUtil.getMediaStoreAlbumCoverUri(song.albumId))
-                                    .build()
-                            )
+                            mediaItems.add(getPlayableSong(mediaId, song))
                         }
                     }
             else -> {
@@ -272,11 +266,12 @@ class AutoMusicProvider(
     }
 
     private fun getPlayableSong(mediaId: String?, song: Song): MediaBrowserCompat.MediaItem {
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
         return AutoMediaItem.with(mContext)
             .asPlayable()
             .path(mediaId, song.id)
             .title(song.title)
-            .subTitle(song.artistName)
+            .subTitle(formattedArtistName)
             .icon(MusicUtil.getMediaStoreAlbumCoverUri(song.albumId))
             .build()
     }

--- a/app/src/main/java/code/name/monkey/retromusic/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/extensions/TextViewExtensions.kt
@@ -1,0 +1,58 @@
+package code.name.monkey.retromusic.extensions
+
+import android.graphics.Color
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextPaint
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.view.View
+import android.widget.TextView
+import code.name.monkey.retromusic.util.ArtistSeparator
+
+fun TextView.setArtistLinks(artistName: String?, onArtistClick: (artist: String) -> Unit) {
+    this.movementMethod = LinkMovementMethod.getInstance()
+    this.highlightColor = Color.TRANSPARENT
+
+    if (artistName.isNullOrEmpty()) {
+        this.text = ""
+        return
+    }
+
+    val artistNames = ArtistSeparator.split(artistName)
+    if (artistNames.isEmpty()) {
+        this.text = artistName
+        return
+    }
+
+    val originalTextColor = this.currentTextColor
+    
+    val builder = SpannableStringBuilder()
+    val separator = ", "
+
+    artistNames.forEachIndexed { index, name ->
+        val startIndex = builder.length
+        builder.append(name)
+        val endIndex = builder.length
+
+        val clickableSpan = object : ClickableSpan() {
+            override fun onClick(widget: View) {
+                widget.cancelPendingInputEvents()
+                onArtistClick(name)
+            }
+
+            override fun updateDrawState(ds: TextPaint) {
+                ds.color = originalTextColor
+                ds.isUnderlineText = false
+            }
+        }
+
+        builder.setSpan(clickableSpan, startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        if (index < artistNames.size - 1) {
+            builder.append(separator)
+        }
+    }
+
+    this.text = builder
+}

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
@@ -283,6 +283,10 @@ class LibraryViewModel(
         emit(repository.artistById(artistId))
     }
 
+    fun artistByName(name: String): LiveData<Artist> = liveData(IO) {
+        emit(repository.artistByName(name))
+    }
+
     fun fetchContributors(): LiveData<List<Contributor>> = liveData(IO) {
         emit(repository.contributor())
     }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumDetailsFragment.kt
@@ -48,7 +48,7 @@ import code.name.monkey.retromusic.fragments.base.AbsMainActivityFragment
 import code.name.monkey.retromusic.glide.RetroGlideExtension
 import code.name.monkey.retromusic.glide.RetroGlideExtension.albumCoverOptions
 import code.name.monkey.retromusic.glide.RetroGlideExtension.artistImageOptions
-import code.name.monkey.retromusic.glide.RetroGlideExtension.asBitmapPalette
+import code.name.monkey.retromusic.glide.RetroGlideExtension.asBitmapPalette 
 import code.name.monkey.retromusic.glide.SingleColorTarget
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.SortOrder.AlbumSongSortOrder.Companion.SONG_A_Z
@@ -117,33 +117,34 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
             }
             albumArtistExists = !album.albumArtist.isNullOrEmpty()
             showAlbum(album)
-            binding.artistImage.transitionName = if (albumArtistExists) {
-                album.albumArtist
-            } else {
-                album.artistId.toString()
-            }
+            
+            val artistNameToUse = if (albumArtistExists) album.albumArtist else album.artistName
+            binding.artistImage.transitionName = artistNameToUse
         }
 
         setupRecyclerView()
         binding.artistImage.setOnClickListener { artistView ->
+            val artistNameToNavigate = ArtistSeparator.split(
+                if (albumArtistExists) album.albumArtist else album.artistName
+            ).firstOrNull() ?: return@setOnClickListener
+
             if (albumArtistExists) {
                 findActivityNavController(R.id.fragment_container)
                     .navigate(
                         R.id.albumArtistDetailsFragment,
-                        bundleOf(EXTRA_ARTIST_NAME to album.albumArtist),
+                        bundleOf(EXTRA_ARTIST_NAME to artistNameToNavigate),
                         null,
-                        FragmentNavigatorExtras(artistView to album.albumArtist.toString())
+                        FragmentNavigatorExtras(artistView to artistNameToNavigate)
                     )
             } else {
                 findActivityNavController(R.id.fragment_container)
                     .navigate(
                         R.id.artistDetailsFragment,
-                        bundleOf(EXTRA_ARTIST_ID to album.artistId),
+                        bundleOf(EXTRA_ARTIST_NAME to artistNameToNavigate),
                         null,
-                        FragmentNavigatorExtras(artistView to album.artistId.toString())
+                        FragmentNavigatorExtras(artistView to artistNameToNavigate)
                     )
             }
-
         }
         binding.fragmentAlbumContent.playAction.setOnClickListener {
             MusicPlayerRemote.openQueue(album.songs, 0, true)
@@ -200,18 +201,24 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
             album.songCount
         )
         binding.fragmentAlbumContent.songTitle.text = songText
-        if (MusicUtil.getYearString(album.year) == "-") {
+
+        val rawArtistName = if (albumArtistExists) album.albumArtist else album.artistName
+        val formattedArtistName = ArtistSeparator.split(rawArtistName).joinToString(", ")
+        val yearString = MusicUtil.getYearString(album.year)
+        val durationString = MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(album.songs))
+
+        if (yearString == "-") {
             binding.albumText.text = String.format(
                 "%s • %s",
-                if (albumArtistExists) album.albumArtist else album.artistName,
-                MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(album.songs))
+                formattedArtistName,
+                durationString
             )
         } else {
             binding.albumText.text = String.format(
                 "%s • %s • %s",
-                album.artistName,
-                MusicUtil.getYearString(album.year),
-                MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(album.songs))
+                formattedArtistName,
+                yearString,
+                durationString
             )
         }
         loadAlbumCover(album)
@@ -248,8 +255,9 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
     private fun moreAlbums(albums: List<Album>) {
         binding.fragmentAlbumContent.moreTitle.show()
         binding.fragmentAlbumContent.moreRecyclerView.show()
+        val formattedArtistName = ArtistSeparator.split(album.artistName).joinToString(", ")
         binding.fragmentAlbumContent.moreTitle.text =
-            String.format(getString(R.string.label_more_from), album.artistName)
+            String.format(getString(R.string.label_more_from), formattedArtistName)
 
         val albumAdapter =
             HorizontalAlbumAdapter(requireActivity() as AppCompatActivity, albums, this)
@@ -291,7 +299,6 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
             moreAlbums(it)
         }
         Glide.with(requireContext())
-            //.forceDownload(PreferenceUtil.isAllowedToDownloadMetadata())
             .load(
                 RetroGlideExtension.getArtistModel(
                     artist,
@@ -308,7 +315,6 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
         Glide.with(requireContext())
             .asBitmapPalette()
             .albumCoverOptions(album.safeGetFirstSong())
-            //.checkIgnoreMediaStore()
             .load(RetroGlideExtension.getSongModel(album.safeGetFirstSong()))
             .into(object : SingleColorTarget(binding.image) {
                 override fun onColorReady(color: Int) {
@@ -423,12 +429,7 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
     private fun setSaveSortOrder(sortOrder: String) {
         PreferenceUtil.albumDetailSongSortOrder = sortOrder
         val songs = when (sortOrder) {
-            SONG_TRACK_LIST -> album.songs.sortedWith { o1, o2 ->
-                o1.trackNumber.compareTo(
-                    o2.trackNumber
-                )
-            }
-
+            SONG_TRACK_LIST -> album.songs.sortedBy { it.trackNumber }
             SONG_A_Z -> {
                 val collator = Collator.getInstance()
                 album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
@@ -439,13 +440,9 @@ class AlbumDetailsFragment : AbsMainActivityFragment(R.layout.fragment_album_det
                 album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
             }
 
-            SONG_DURATION -> album.songs.sortedWith { o1, o2 ->
-                o1.duration.compareTo(
-                    o2.duration
-                )
-            }
+            SONG_DURATION -> album.songs.sortedBy { it.duration }
 
-            else -> throw IllegalArgumentException("invalid $sortOrder")
+            else -> album.songs
         }
         album = album.copy(songs = songs)
         simpleSongAdapter.swapDataSet(album.songs)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AbsArtistDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AbsArtistDetailsFragment.kt
@@ -57,7 +57,9 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
     abstract val detailsViewModel: ArtistDetailsViewModel
     abstract val artistId: Long?
     abstract val artistName: String?
-    private lateinit var artist: Artist
+    
+    private var artist: Artist? = null
+    
     private lateinit var songAdapter: SimpleSongAdapter
     private lateinit var albumAdapter: HorizontalAlbumAdapter
     private var forceDownload: Boolean = false
@@ -84,7 +86,9 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
         mainActivity.addMusicServiceEventListener(detailsViewModel)
         mainActivity.setSupportActionBar(binding.toolbar)
         binding.toolbar.title = null
-        binding.artistCoverContainer.transitionName = (artistId ?: artistName).toString()
+        
+        binding.artistCoverContainer.transitionName = artistName ?: artistId?.toString()
+        
         postponeEnterTransition()
         detailsViewModel.getArtist().observe(viewLifecycleOwner) {
             view.doOnPreDraw {
@@ -95,10 +99,10 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
         setupRecyclerView()
 
         binding.fragmentArtistContent.playAction.apply {
-            setOnClickListener { MusicPlayerRemote.openQueue(artist.sortedSongs, 0, true) }
+            setOnClickListener { artist?.let { MusicPlayerRemote.openQueue(it.sortedSongs, 0, true) } }
         }
         binding.fragmentArtistContent.shuffleAction.apply {
-            setOnClickListener { MusicPlayerRemote.openAndShuffleQueue(artist.songs, true) }
+            setOnClickListener { artist?.let { MusicPlayerRemote.openAndShuffleQueue(it.songs, true) } }
         }
 
         binding.fragmentArtistContent.biographyText.setOnClickListener {
@@ -149,7 +153,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
             R.plurals.albumSongs, artist.songCount, artist.songCount
         )
         val albumText = resources.getQuantityString(
-            R.plurals.albums, artist.songCount, artist.songCount
+            R.plurals.albums, artist.albumCount, artist.albumCount
         )
         binding.fragmentArtistContent.songTitle.text = songText
         binding.fragmentArtistContent.albumTitle.text = albumText
@@ -195,9 +199,8 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
             }
         }
 
-        // If the "lang" parameter is set and no biography is given, retry with default language
         if (biography == null && lang != null) {
-            loadBiography(artist.name, null)
+            artist?.let { loadBiography(it.name, null) }
         }
     }
 
@@ -230,11 +233,9 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
     }
 
     override fun onMenuItemSelected(item: MenuItem): Boolean {
-        return handleSortOrderMenuItem(item)
-    }
-
-    private fun handleSortOrderMenuItem(item: MenuItem): Boolean {
-        val songs = artist.songs
+        val currentArtist = artist ?: return false
+        val songs = currentArtist.songs
+        
         when (item.itemId) {
             android.R.id.home -> findNavController().navigateUp()
             R.id.action_play_next -> {
@@ -269,7 +270,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
                 showToast(resources.getString(R.string.updating))
                 lifecycleScope.launch {
                     CustomArtistImageUtil.getInstance(requireContext())
-                        .resetCustomArtistImage(artist)
+                        .resetCustomArtistImage(currentArtist)
                 }
                 forceDownload = true
                 return true
@@ -290,9 +291,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
                         R.id.action_sort_order_album -> SortOrder.ArtistSongSortOrder.SONG_ALBUM
                         R.id.action_sort_order_year -> SortOrder.ArtistSongSortOrder.SONG_YEAR
                         R.id.action_sort_order_song_duration -> SortOrder.ArtistSongSortOrder.SONG_DURATION
-                        else -> {
-                            throw IllegalArgumentException("invalid ${item.title}")
-                        }
+                        else -> return@setOnMenuItemClickListener false
                     }
                     item.isChecked = true
                     setSaveSortOrder(sortOrder)
@@ -305,7 +304,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
 
     private fun setSaveSortOrder(sortOrder: String) {
         PreferenceUtil.artistDetailSongSortOrder = sortOrder
-        songAdapter.swapDataSet(artist.sortedSongs)
+        artist?.let { songAdapter.swapDataSet(it.sortedSongs) }
     }
 
     private fun setupAlbumSortButton() {
@@ -319,9 +318,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
                         R.id.action_sort_order_title_desc -> SortOrder.ArtistAlbumSortOrder.ALBUM_Z_A
                         R.id.action_sort_order_year -> SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR_ASC
                         R.id.action_sort_order_year_desc -> SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR
-                        else -> {
-                            throw IllegalArgumentException("invalid ${item.title}")
-                        }
+                        else -> return@setOnMenuItemClickListener false
                     }
                     item.isChecked = true
                     setSaveAlbumSortOrder(sortOrder)
@@ -334,7 +331,7 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
 
     private fun setSaveAlbumSortOrder(sortOrder: String) {
         PreferenceUtil.artistAlbumSortOrder = sortOrder
-        albumAdapter.swapDataSet(artist.sortedAlbums)
+        artist?.let { albumAdapter.swapDataSet(it.sortedAlbums) }
     }
 
     private fun setUpAlbumSortOrderMenu(sortOrder: Menu) {
@@ -350,10 +347,6 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
 
             SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR -> sortOrder.findItem(R.id.action_sort_order_year_desc).isChecked =
                 true
-
-            else -> {
-                throw IllegalArgumentException("invalid $savedAlbumSortOrder")
-            }
         }
     }
 
@@ -373,10 +366,6 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
 
             SortOrder.ArtistSongSortOrder.SONG_DURATION -> sortOrder.findItem(R.id.action_sort_order_song_duration).isChecked =
                 true
-
-            else -> {
-                throw IllegalArgumentException("invalid $savedSongSortOrder")
-            }
         }
     }
 
@@ -384,8 +373,10 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             lifecycleScope.launch {
                 if (uri != null) {
-                    CustomArtistImageUtil.getInstance(requireContext())
-                        .setCustomArtistImage(artist, uri)
+                    artist?.let {
+                        CustomArtistImageUtil.getInstance(requireContext())
+                            .setCustomArtistImage(it, uri)
+                    }
                 }
             }
         }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AlbumArtistDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AlbumArtistDetailsFragment.kt
@@ -25,8 +25,10 @@ class AlbumArtistDetailsFragment : AbsArtistDetailsFragment() {
     override val detailsViewModel: ArtistDetailsViewModel by viewModel {
         parametersOf(null, arguments.extraArtistName)
     }
+
     override val artistId: Long?
         get() = null
-    override val artistName: String
+
+    override val artistName: String?
         get() = arguments.extraArtistName
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsFragment.kt
@@ -20,12 +20,14 @@ import org.koin.core.parameter.parametersOf
 
 class ArtistDetailsFragment : AbsArtistDetailsFragment() {
     private val arguments by navArgs<ArtistDetailsFragmentArgs>()
+    
     override val detailsViewModel: ArtistDetailsViewModel by viewModel {
-        parametersOf(arguments.extraArtistId, null)
+        parametersOf(arguments.extraArtistId, arguments.extraArtistName)
     }
-    override val artistId: Long
-        get() = arguments.extraArtistId
-    override val artistName: String?
-        get() = null
 
+    override val artistId: Long?
+        get() = if (arguments.extraArtistId != -1L) arguments.extraArtistId else null
+
+    override val artistName: String?
+        get() = arguments.extraArtistName
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsViewModel.kt
@@ -36,9 +36,11 @@ class ArtistDetailsViewModel(
 
     private fun fetchArtist() {
         viewModelScope.launch(IO) {
-            artistId?.let { artistDetails.postValue(realRepository.artistById(it)) }
-
-            artistName?.let { artistDetails.postValue(realRepository.albumArtistByName(it)) }
+            if (artistName != null) {
+                artistDetails.postValue(realRepository.artistByName(artistName))
+            } else if (artistId != null && artistId != -1L) {
+                artistDetails.postValue(realRepository.artistById(artistId))
+            }
         }
     }
 

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistsFragment.kt
@@ -40,11 +40,8 @@ class ArtistsFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, Gri
     IArtistClickListener, IAlbumArtistClickListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        libraryViewModel.getArtists().observe(viewLifecycleOwner) {
-            if (it.isNotEmpty())
-                adapter?.swapDataSet(it)
-            else
-                adapter?.swapDataSet(listOf())
+        libraryViewModel.getArtists().observe(viewLifecycleOwner) { artists ->
+            adapter?.swapDataSet(artists ?: emptyList())
         }
     }
 
@@ -58,10 +55,10 @@ class ArtistsFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, Gri
         get() = true
 
     override fun onShuffleClicked() {
-        libraryViewModel.getArtists().value?.let {
+        adapter?.dataSet?.let { artists ->
             MusicPlayerRemote.setShuffleMode(MusicService.SHUFFLE_MODE_NONE)
             MusicPlayerRemote.openQueue(
-                queue = it.shuffled().flatMap { artist -> artist.songs },
+                queue = artists.shuffled().flatMap { artist -> artist.songs },
                 startPosition = 0,
                 startPlaying = true
             )
@@ -133,12 +130,12 @@ class ArtistsFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, Gri
         }
     }
 
-    override fun onArtist(artistId: Long, view: View) {
+    override fun onArtist(artistName: String, view: View) {
         findNavController().navigate(
             R.id.artistDetailsFragment,
-            bundleOf(EXTRA_ARTIST_ID to artistId),
+            bundleOf(EXTRA_ARTIST_NAME to artistName),
             null,
-            FragmentNavigatorExtras(view to artistId.toString())
+            FragmentNavigatorExtras(view to artistName)
         )
         reenterTransition = null
     }
@@ -164,7 +161,6 @@ class ArtistsFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, Gri
         setupLayoutMenu(layoutItem.subMenu!!)
         setUpSortOrderMenu(menu.findItem(R.id.action_sort_order).subMenu!!)
         setupAlbumArtistMenu(menu)
-        //Setting up cast button
         requireContext().setUpMediaRouteButton(menu)
     }
 
@@ -293,12 +289,12 @@ class ArtistsFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, Gri
         item: MenuItem
     ): Boolean {
         val layoutRes = when (item.itemId) {
-            R.id.action_layout_normal -> R.layout.item_grid
-            R.id.action_layout_card -> R.layout.item_card
-            R.id.action_layout_colored_card -> R.layout.item_card_color
-            R.id.action_layout_circular -> R.layout.item_grid_circle
-            R.id.action_layout_image -> R.layout.image
-            R.id.action_layout_gradient_image -> R.layout.item_image_gradient
+            R.layout.item_grid -> R.layout.item_grid
+            R.layout.item_card -> R.layout.item_card
+            R.layout.item_card_color -> R.layout.item_card_color
+            R.layout.item_grid_circle -> R.layout.item_grid_circle
+            R.layout.image -> R.layout.image
+            R.layout.item_image_gradient -> R.layout.item_image_gradient
             else -> PreferenceUtil.artistGridStyle.layoutResId
         }
         if (layoutRes != PreferenceUtil.artistGridStyle.layoutResId) {

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/base/AbsPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/base/AbsPlayerFragment.kt
@@ -37,28 +37,15 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.findNavController
 import androidx.navigation.navOptions
 import androidx.viewpager.widget.ViewPager
-import code.name.monkey.appthemehelper.util.VersionUtils
 import code.name.monkey.retromusic.EXTRA_ALBUM_ID
-import code.name.monkey.retromusic.EXTRA_ARTIST_ID
 import code.name.monkey.retromusic.R
 import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.activities.tageditor.AbsTagEditorActivity
 import code.name.monkey.retromusic.activities.tageditor.SongTagEditorActivity
 import code.name.monkey.retromusic.db.PlaylistEntity
 import code.name.monkey.retromusic.db.toSongEntity
-import code.name.monkey.retromusic.dialogs.AddToPlaylistDialog
-import code.name.monkey.retromusic.dialogs.CreatePlaylistDialog
-import code.name.monkey.retromusic.dialogs.DeleteSongsDialog
-import code.name.monkey.retromusic.dialogs.PlaybackSpeedDialog
-import code.name.monkey.retromusic.dialogs.SleepTimerDialog
-import code.name.monkey.retromusic.dialogs.SongDetailDialog
-import code.name.monkey.retromusic.dialogs.SongShareDialog
-import code.name.monkey.retromusic.extensions.currentFragment
-import code.name.monkey.retromusic.extensions.getTintedDrawable
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.keepScreenOn
-import code.name.monkey.retromusic.extensions.showToast
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.dialogs.*
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.LibraryViewModel
 import code.name.monkey.retromusic.fragments.NowPlayingScreen
 import code.name.monkey.retromusic.fragments.ReloadType
@@ -171,18 +158,7 @@ abstract class AbsPlayerFragment(@LayoutRes layout: Int) : AbsMusicServiceFragme
             }
 
             R.id.action_go_to_album -> {
-                //Hide Bottom Bar First, else Bottom Sheet doesn't collapse fully
-                mainActivity.setBottomNavVisibility(false)
-                mainActivity.collapsePanel()
-                requireActivity().findNavController(R.id.fragment_container).navigate(
-                    R.id.albumDetailsFragment,
-                    bundleOf(EXTRA_ALBUM_ID to song.albumId)
-                )
-                return true
-            }
-
-            R.id.action_go_to_artist -> {
-                goToArtist(requireActivity())
+                goToAlbum(requireActivity())
                 return true
             }
 
@@ -410,28 +386,6 @@ abstract class AbsPlayerFragment(@LayoutRes layout: Int) : AbsMusicServiceFragme
     companion object {
         val TAG: String = AbsPlayerFragment::class.java.simpleName
         const val VISIBILITY_ANIM_DURATION: Long = 300
-    }
-}
-
-fun goToArtist(activity: Activity) {
-    if (activity !is MainActivity) return
-    val song = MusicPlayerRemote.currentSong
-    activity.apply {
-
-        // Remove exit transition of current fragment so
-        // it doesn't exit with a weird transition
-        currentFragment(R.id.fragment_container)?.exitTransition = null
-
-        //Hide Bottom Bar First, else Bottom Sheet doesn't collapse fully
-        setBottomNavVisibility(false)
-        if (getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
-            collapsePanel()
-        }
-
-        findNavController(R.id.fragment_container).navigate(
-            R.id.artistDetailsFragment,
-            bundleOf(EXTRA_ARTIST_ID to song.artistId)
-        )
     }
 }
 

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/other/DetailListFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/other/DetailListFragment.kt
@@ -219,13 +219,12 @@ class DetailListFragment : AbsMainActivityFragment(R.layout.fragment_playlist_de
         return if (RetroUtil.isLandscape) 4 else 2
     }
 
-
-    override fun onArtist(artistId: Long, view: View) {
+    override fun onArtist(artistName: String, view: View) {
         findNavController().navigate(
             R.id.artistDetailsFragment,
-            bundleOf(EXTRA_ARTIST_ID to artistId),
+            bundleOf(EXTRA_ARTIST_NAME to artistName),
             null,
-            FragmentNavigatorExtras(view to artistId.toString())
+            FragmentNavigatorExtras(view to artistName)
         )
     }
 

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/other/MiniPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/other/MiniPlayerFragment.kt
@@ -36,6 +36,7 @@ import code.name.monkey.retromusic.glide.RetroGlideExtension.songCoverOptions
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.MusicProgressViewUpdateHelper
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.RetroUtil
 import com.bumptech.glide.Glide
@@ -98,21 +99,18 @@ open class MiniPlayerFragment : AbsMusicServiceFragment(R.layout.fragment_mini_p
         val title = song.title.toSpannable()
         title.setSpan(ForegroundColorSpan(textColorPrimary()), 0, title.length, 0)
 
-        val text = song.artistName.toSpannable()
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        val text = formattedArtistName.toSpannable()
         text.setSpan(ForegroundColorSpan(textColorSecondary()), 0, text.length, 0)
 
         builder.append(title).append(" • ").append(text)
 
         binding.miniPlayerTitle.isSelected = true
         binding.miniPlayerTitle.text = builder
-
-//        binding.title.isSelected = true
-//        binding.title.text = song.title
-//        binding.text.isSelected = true
-//        binding.text.text = song.artistName
     }
 
     private fun updateSongCover() {
+        if (!isAdded) return
         val song = MusicPlayerRemote.currentSong
         Glide.with(requireContext())
             .load(RetroGlideExtension.getSongModel(song))
@@ -137,6 +135,7 @@ open class MiniPlayerFragment : AbsMusicServiceFragment(R.layout.fragment_mini_p
     }
 
     override fun onUpdateProgressViews(progress: Int, total: Int) {
+        if (_binding == null) return
         binding.progressBar.max = total
         binding.progressBar.progress = progress
     }
@@ -152,6 +151,7 @@ open class MiniPlayerFragment : AbsMusicServiceFragment(R.layout.fragment_mini_p
     }
 
     protected fun updatePlayPauseDrawableState() {
+        if (_binding == null) return
         if (MusicPlayerRemote.isPlaying) {
             binding.miniPlayerPlayPauseButton.setImageResource(R.drawable.ic_pause)
         } else {

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/adaptive/AdaptiveFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/adaptive/AdaptiveFragment.kt
@@ -25,6 +25,7 @@ import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 
 class AdaptiveFragment : AbsPlayerFragment(R.layout.fragment_adaptive_player) {
@@ -81,10 +82,8 @@ class AdaptiveFragment : AbsPlayerFragment(R.layout.fragment_adaptive_player) {
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
-        binding.playerToolbar.apply {
-            title = song.title
-            subtitle = song.artistName
-        }
+        binding.playerToolbar.title = song.title
+        binding.playerToolbar.subtitle = ArtistSeparator.split(song.artistName).joinToString(", ")
     }
 
     override fun toggleFavorite(song: Song) {

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/blur/BlurPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/blur/BlurPlaybackControlsFragment.kt
@@ -21,21 +21,24 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentBlurPlayerPlaybackControlsBinding
-import code.name.monkey.retromusic.extensions.applyColor
-import code.name.monkey.retromusic.extensions.getSongInfo
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.show
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
 
 class BlurPlaybackControlsFragment :
@@ -73,15 +76,46 @@ class BlurPlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
+        
         binding.text.setOnClickListener {
-            goToArtist(requireActivity())
+            handleArtistClick()
         }
+    }
+
+    private fun handleArtistClick() {
+        val activity = requireActivity() as? MainActivity ?: return
+        val song = MusicPlayerRemote.currentSong
+        val artistNames = ArtistSeparator.split(song.artistName)
+
+        if (artistNames.size > 1) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(getString(R.string.go_to_artist))
+                .setItems(artistNames.toTypedArray()) { _, which ->
+                    navigateToArtist(activity, artistNames[which])
+                }
+                .show()
+        } else if (artistNames.isNotEmpty()) {
+            navigateToArtist(activity, artistNames[0])
+        }
+    }
+
+    private fun navigateToArtist(activity: MainActivity, artistName: String) {
+        activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+        activity.setBottomNavVisibility(false)
+        if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+            activity.collapsePanel()
+        }
+        activity.findNavController(R.id.fragment_container).navigate(
+            R.id.artistDetailsFragment,
+            bundleOf(EXTRA_ARTIST_NAME to artistName)
+        )
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = String.format("%s • %s", song.artistName, song.albumName)
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        binding.text.text = String.format("%s • %s", formattedArtistName, song.albumName)
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.show()

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/card/CardPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/card/CardPlaybackControlsFragment.kt
@@ -20,19 +20,23 @@ import android.view.View
 import android.widget.ImageButton
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentCardPlayerPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class CardPlaybackControlsFragment :
     AbsPlayerControlsFragment(R.layout.fragment_card_player_playback_controls) {
@@ -71,15 +75,28 @@ class CardPlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(MusicPlayerRemote.currentSong)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/cardblur/CardBlurFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/cardblur/CardBlurFragment.kt
@@ -20,14 +20,18 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import androidx.preference.PreferenceManager
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.NEW_BLUR_AMOUNT
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentCardBlurPlayerBinding
-import code.name.monkey.retromusic.extensions.drawAboveSystemBars
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
+import code.name.monkey.retromusic.fragments.base.goToAlbum
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.fragments.player.normal.PlayerFragment
 import code.name.monkey.retromusic.glide.BlurTransformation
@@ -40,6 +44,7 @@ import code.name.monkey.retromusic.util.PreferenceUtil.blurAmount
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class CardBlurFragment : AbsPlayerFragment(R.layout.fragment_card_blur_player),
     SharedPreferences.OnSharedPreferenceChangeListener {
@@ -95,6 +100,12 @@ class CardBlurFragment : AbsPlayerFragment(R.layout.fragment_card_blur_player),
         setUpSubFragments()
         setUpPlayerToolbar()
         binding.playerToolbar.drawAboveSystemBars()
+
+        binding.title.isSelected = true
+        binding.title.setOnClickListener {
+            goToAlbum(requireActivity())
+        }
+        binding.text.isSelected = true
     }
 
     private fun setUpSubFragments() {
@@ -130,14 +141,29 @@ class CardBlurFragment : AbsPlayerFragment(R.layout.fragment_card_blur_player),
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
-        binding.run {
-            title.text = song.title
-            text.text = song.artistName
+        binding.title.text = song.title
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
         }
     }
 
     private fun updateBlur() {
         // https://github.com/bumptech/glide/issues/527#issuecomment-148840717
+        if (!isAdded) return
         Glide.with(this)
             .load(RetroGlideExtension.getSongModel(MusicPlayerRemote.currentSong))
             .simpleSongCoverOptions(MusicPlayerRemote.currentSong)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/circle/CirclePlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/circle/CirclePlayerFragment.kt
@@ -27,17 +27,20 @@ import android.view.animation.Animation
 import android.view.animation.LinearInterpolator
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.getSystemService
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentCirclePlayerBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.MusicSeekSkipTouchListener
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.glide.RetroGlideExtension
 import code.name.monkey.retromusic.glide.RetroGlideExtension.simpleSongCoverOptions
 import code.name.monkey.retromusic.glide.crossfadeListener
@@ -52,6 +55,7 @@ import code.name.monkey.retromusic.volume.AudioVolumeObserver
 import code.name.monkey.retromusic.volume.OnAudioVolumeChangedListener
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.slider.Slider
 import me.tankery.lib.circularseekbar.CircularSeekBar
 
@@ -90,9 +94,6 @@ class CirclePlayerFragment : AbsPlayerFragment(R.layout.fragment_circle_player),
         binding.title.isSelected = true
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
-        }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
         }
         binding.songInfo.drawAboveSystemBars()
     }
@@ -231,7 +232,23 @@ class CirclePlayerFragment : AbsPlayerFragment(R.layout.fragment_circle_player),
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)
@@ -239,6 +256,7 @@ class CirclePlayerFragment : AbsPlayerFragment(R.layout.fragment_circle_player),
         } else {
             binding.songInfo.hide()
         }
+        if (!isAdded) return
         Glide.with(this)
             .load(RetroGlideExtension.getSongModel(MusicPlayerRemote.currentSong))
             .simpleSongCoverOptions(MusicPlayerRemote.currentSong)
@@ -259,8 +277,9 @@ class CirclePlayerFragment : AbsPlayerFragment(R.layout.fragment_circle_player),
     }
 
     override fun onAudioVolumeChanged(currentVolume: Int, maxVolume: Int) {
-        _binding?.volumeSeekBar?.max = maxVolume.toFloat()
-        _binding?.volumeSeekBar?.progress = currentVolume.toFloat()
+        if (_binding == null) return
+        binding.volumeSeekBar.max = maxVolume.toFloat()
+        binding.volumeSeekBar.progress = currentVolume.toFloat()
     }
 
     override fun onDestroyView() {
@@ -315,11 +334,10 @@ class CirclePlayerFragment : AbsPlayerFragment(R.layout.fragment_circle_player),
     override fun onUpdateProgressViews(progress: Int, total: Int) {
         val progressSlider = binding.progressSlider
         progressSlider.valueTo = total.toFloat()
-
-        progressSlider.valueTo = total.toFloat()
-
-        progressSlider.value =
-            progress.toFloat().coerceIn(progressSlider.valueFrom, progressSlider.valueTo)
+        
+        if (!isSeeking) {
+            progressSlider.value = progress.toFloat().coerceIn(progressSlider.valueFrom, progressSlider.valueTo)
+        }
 
         binding.songTotalTime.text = MusicUtil.getReadableDurationString(total.toLong())
         binding.songCurrentProgress.text = MusicUtil.getReadableDurationString(progress.toLong())

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/classic/ClassicPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/classic/ClassicPlayerFragment.kt
@@ -29,14 +29,17 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
-import androidx.navigation.fragment.findNavController
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.TintHelper
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.adapter.song.PlayingQueueAdapter
 import code.name.monkey.retromusic.databinding.FragmentClassicPlayerBinding
 import code.name.monkey.retromusic.extensions.*
@@ -44,7 +47,6 @@ import code.name.monkey.retromusic.fragments.MusicSeekSkipTouchListener
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.other.VolumeFragment
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
@@ -103,6 +105,7 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
         }
 
         override fun onStateChanged(bottomSheet: View, newState: Int) {
+            onBackPressedCallback.isEnabled = newState == BottomSheetBehavior.STATE_EXPANDED
             when (newState) {
                 BottomSheetBehavior.STATE_EXPANDED,
                 BottomSheetBehavior.STATE_DRAGGING -> {
@@ -117,6 +120,17 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
                 else -> {
                     mainActivity.getBottomSheetBehavior().isDraggable = true
                 }
+            }
+        }
+    }
+
+    private val onBackPressedCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            if (_binding != null && getQueuePanel().state == BottomSheetBehavior.STATE_EXPANDED) {
+                getQueuePanel().state = BottomSheetBehavior.STATE_COLLAPSED
+            } else {
+                isEnabled = false
+                requireActivity().onBackPressedDispatcher.onBackPressed()
             }
         }
     }
@@ -136,7 +150,6 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
         hideVolumeIfAvailable()
         setupRecyclerView()
 
-        // Check if the device is in landscape mode
         if (isLandscapeMode()) {
             resizePlayingQueue()
         }
@@ -171,19 +184,7 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
-        requireActivity().onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                if (getQueuePanel().state == BottomSheetBehavior.STATE_EXPANDED) {
-                    getQueuePanel().state = BottomSheetBehavior.STATE_COLLAPSED
-                }
-                else{
-                    mainActivity.getBottomSheetBehavior().state=BottomSheetBehavior.STATE_COLLAPSED
-                }
-            }
-        })
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, onBackPressedCallback)
     }
 
 
@@ -226,7 +227,19 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            val activity = requireActivity() as? MainActivity ?: return@setArtistLinks
+            activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+            activity.setBottomNavVisibility(false)
+            if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+                activity.collapsePanel()
+            }
+            activity.findNavController(R.id.fragment_container).navigate(
+                R.id.artistDetailsFragment,
+                bundleOf(EXTRA_ARTIST_NAME to artistName)
+            )
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.playerControlsContainer.songInfo.text = getSongInfo(song)
@@ -353,6 +366,7 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
     }
 
     override fun onUpdateProgressViews(progress: Int, total: Int) {
+        if (_binding == null) return
         binding.playerControlsContainer.progressSlider.max = total
 
         val animator = ObjectAnimator.ofInt(
@@ -395,23 +409,17 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
             return
         }
 
-        // Check if the device is in landscape mode
         if (isLandscapeMode()) {
             calculateLandScapePeekHeight()
         } else {
             val height = binding.playerContainer.height
             val width = binding.playerContainer.width
-            val finalHeight = height - width
+            val finalHeight = height - (binding.playerControlsContainer.root.height + width)
             val panel = getQueuePanel()
             panel.peekHeight = finalHeight
         }
     }
 
-
-    /**
-     * What am doing here is getting the controls  height, and adding the toolbar and statusbar height to itm
-     * then i subtract it from the screen height to get a peek height
-     */
     private fun calculateLandScapePeekHeight() {
         val height = binding.playerControlsContainer.root.height
         val appbarHeight = binding.playerToolbar.height
@@ -594,14 +602,11 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
         oldBottom: Int
     ) {
 
-        // Check if the device is in landscape mode
         if (isLandscapeMode()) {
             calculateLandScapePeekHeight()
 
-            //get background color from viewModel
             val backgroundColor = libraryViewModel.paletteColor.value
 
-            //check if color is already applied, if not applied then update navigationBarColor
             backgroundColor?.let { color ->
                 if (isLandscapeMode()) {
                     val window = requireActivity().window
@@ -624,8 +629,6 @@ class ClassicPlayerFragment : AbsPlayerFragment(R.layout.fragment_classic_player
 
     private fun isLandscapeMode(): Boolean {
         val config = resources.configuration;
-
-        // Check if the device is in landscape mode
         return config.orientation == Configuration.ORIENTATION_LANDSCAPE
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/color/ColorPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/color/ColorPlaybackControlsFragment.kt
@@ -23,20 +23,21 @@ import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentColorPlayerPlaybackControlsBinding
-import code.name.monkey.retromusic.extensions.applyColor
-import code.name.monkey.retromusic.extensions.getSongInfo
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.show
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.slider.Slider
 import kotlin.math.sqrt
 
@@ -77,15 +78,26 @@ class ColorPlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            val activity = requireActivity()
+            if (activity is MainActivity) {
+                activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+                activity.setBottomNavVisibility(false)
+                if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+                    activity.collapsePanel()
+                }
+                activity.findNavController(R.id.fragment_container).navigate(
+                    R.id.artistDetailsFragment,
+                    bundleOf(EXTRA_ARTIST_NAME to artistName)
+                )
+            }
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/fit/FitPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/fit/FitPlaybackControlsFragment.kt
@@ -20,18 +20,22 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentFitPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class FitPlaybackControlsFragment :
     AbsPlayerControlsFragment(R.layout.fragment_fit_playback_controls) {
@@ -71,15 +75,29 @@ class FitPlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
+        
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)
             binding.songInfo.show()

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/flat/FlatPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/flat/FlatPlaybackControlsFragment.kt
@@ -20,21 +20,25 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentFlatPlayerPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.MusicProgressViewUpdateHelper.Callback
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class FlatPlaybackControlsFragment :
     AbsPlayerControlsFragment(R.layout.fragment_flat_player_playback_controls), Callback {
@@ -71,9 +75,6 @@ class FlatPlaybackControlsFragment :
         binding.text.isSelected = true
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
-        }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
         }
     }
 
@@ -164,7 +165,24 @@ class FlatPlaybackControlsFragment :
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
+        
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)
             binding.songInfo.show()

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/full/FullPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/full/FullPlaybackControlsFragment.kt
@@ -25,11 +25,14 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ColorUtil
-import code.name.monkey.appthemehelper.util.VersionUtils
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentFullPlayerControlsBinding
 import code.name.monkey.retromusic.db.PlaylistEntity
 import code.name.monkey.retromusic.db.toSongEntity
@@ -38,13 +41,13 @@ import code.name.monkey.retromusic.fragments.LibraryViewModel
 import code.name.monkey.retromusic.fragments.ReloadType
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.service.MusicService
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.slider.Slider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -94,9 +97,6 @@ class FullPlaybackControlsFragment :
         binding.title.isSelected = true
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
-        }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
         }
     }
 
@@ -149,7 +149,22 @@ class FullPlaybackControlsFragment :
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            val activity = requireActivity()
+            if (activity is MainActivity) {
+                activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+                activity.setBottomNavVisibility(false)
+                if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+                    activity.collapsePanel()
+                }
+                activity.findNavController(R.id.fragment_container).navigate(
+                    R.id.artistDetailsFragment,
+                    bundleOf(EXTRA_ARTIST_NAME to artistName)
+                )
+            }
+        }
+
         updateIsFavorite()
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/full/FullPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/full/FullPlayerFragment.kt
@@ -19,23 +19,26 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentFullBinding
-import code.name.monkey.retromusic.extensions.drawAboveSystemBars
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.show
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.player.CoverLyricsFragment
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.glide.RetroGlideExtension
 import code.name.monkey.retromusic.glide.RetroGlideExtension.artistImageOptions
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.bumptech.glide.Glide
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class FullPlayerFragment : AbsPlayerFragment(R.layout.fragment_full) {
     private var _binding: FragmentFullBinding? = null
@@ -62,15 +65,41 @@ class FullPlayerFragment : AbsPlayerFragment(R.layout.fragment_full) {
 
         setUpSubFragments()
         setUpPlayerToolbar()
-        setupArtist()
+        setupArtistClick()
         binding.nextSong.isSelected = true
         binding.playbackControlsFragment.drawAboveSystemBars()
     }
 
-    private fun setupArtist() {
+    private fun setupArtistClick() {
         binding.artistImage.setOnClickListener {
-            goToArtist(mainActivity)
+            val activity = requireActivity() as? MainActivity ?: return@setOnClickListener
+            val song = MusicPlayerRemote.currentSong
+            val artistNames = ArtistSeparator.split(song.artistName)
+
+            if (artistNames.size > 1) {
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.go_to_artist))
+                    .setItems(artistNames.toTypedArray()) { dialog, which ->
+                        navigateToArtist(activity, artistNames[which])
+                        dialog.dismiss()
+                    }
+                    .show()
+            } else if (artistNames.isNotEmpty()) {
+                navigateToArtist(activity, artistNames[0])
+            }
         }
+    }
+
+    private fun navigateToArtist(activity: MainActivity, artistName: String) {
+        activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+        activity.setBottomNavVisibility(false)
+        if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+            activity.collapsePanel()
+        }
+        activity.findNavController(R.id.fragment_container).navigate(
+            R.id.artistDetailsFragment,
+            bundleOf(EXTRA_ARTIST_NAME to artistName)
+        )
     }
 
     private fun setUpSubFragments() {
@@ -80,11 +109,9 @@ class FullPlayerFragment : AbsPlayerFragment(R.layout.fragment_full) {
         coverFragment.removeSlideEffect()
     }
 
-    override fun onShow() {
-    }
+    override fun onShow() {}
 
-    override fun onHide() {
-    }
+    override fun onHide() {}
 
     override fun toolbarIconColor(): Int {
         return Color.WHITE
@@ -129,16 +156,20 @@ class FullPlayerFragment : AbsPlayerFragment(R.layout.fragment_full) {
     }
 
     private fun updateArtistImage() {
-        libraryViewModel.artist(MusicPlayerRemote.currentSong.artistId)
-            .observe(viewLifecycleOwner) { artist ->
-                if (artist.id != -1L) {
-                    Glide.with(requireActivity())
+        if (!isAdded) return
+        val song = MusicPlayerRemote.currentSong
+        val mainArtistName = ArtistSeparator.split(song.artistName).firstOrNull()
+        if (mainArtistName != null) {
+            libraryViewModel.artistByName(mainArtistName).observe(viewLifecycleOwner) { artist ->
+                if (artist != null && artist.id != -1L) {
+                    if (!isAdded) return@observe
+                    Glide.with(this)
                         .load(RetroGlideExtension.getArtistModel(artist))
                         .artistImageOptions(artist)
                         .into(binding.artistImage)
                 }
-
             }
+        }
     }
 
     override fun onQueueChanged() {
@@ -147,6 +178,7 @@ class FullPlayerFragment : AbsPlayerFragment(R.layout.fragment_full) {
     }
 
     private fun updateLabel() {
+        if (!isAdded) return
         if ((MusicPlayerRemote.playingQueue.size - 1) == (MusicPlayerRemote.position)) {
             binding.nextSongLabel.setText(R.string.last_song)
             binding.nextSong.hide()

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/gradient/GradientPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/gradient/GradientPlayerFragment.kt
@@ -26,29 +26,25 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import code.name.monkey.appthemehelper.util.ColorUtil
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.adapter.song.PlayingQueueAdapter
 import code.name.monkey.retromusic.databinding.FragmentGradientPlayerBinding
-import code.name.monkey.retromusic.extensions.applyColor
-import code.name.monkey.retromusic.extensions.drawAboveSystemBars
-import code.name.monkey.retromusic.extensions.getBottomInsets
-import code.name.monkey.retromusic.extensions.getSongInfo
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.ripAlpha
-import code.name.monkey.retromusic.extensions.show
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.MusicSeekSkipTouchListener
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.other.VolumeFragment
 import code.name.monkey.retromusic.fragments.player.CoverLyricsFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
@@ -178,9 +174,7 @@ class GradientPlayerFragment : AbsPlayerFragment(R.layout.fragment_gradient_play
         binding.playbackControlsFragment.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.playbackControlsFragment.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
+        
         ViewCompat.setOnApplyWindowInsetsListener(
             (binding.container)
         ) { v: View, insets: WindowInsetsCompat ->
@@ -360,13 +354,30 @@ class GradientPlayerFragment : AbsPlayerFragment(R.layout.fragment_gradient_play
     override fun onQueueChanged() {
         super.onQueueChanged()
         updateLabel()
-        playingQueueAdapter?.swapDataSet(MusicPlayerRemote.playingQueue)
+        playingQueueAdapter?.swapDataSet(MusicPlayerRemote.playingQueue, -1) // Position is not needed here
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.playbackControlsFragment.title.text = song.title
-        binding.playbackControlsFragment.text.text = song.artistName
+        
+        binding.playbackControlsFragment.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
+
         updateLabel()
         if (PreferenceUtil.isSongInfo) {
             binding.playbackControlsFragment.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/home/HomePlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/home/HomePlayerFragment.kt
@@ -18,16 +18,24 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentHomePlayerBinding
 import code.name.monkey.retromusic.extensions.colorControlNormal
+import code.name.monkey.retromusic.extensions.currentFragment
+import code.name.monkey.retromusic.extensions.setArtistLinks
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
+import code.name.monkey.retromusic.fragments.base.goToAlbum
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.MusicProgressViewUpdateHelper
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class HomePlayerFragment : AbsPlayerFragment(R.layout.fragment_home_player),
     MusicProgressViewUpdateHelper.Callback {
@@ -46,6 +54,10 @@ class HomePlayerFragment : AbsPlayerFragment(R.layout.fragment_home_player),
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentHomePlayerBinding.bind(view)
         setUpPlayerToolbar()
+
+        binding.title.setOnClickListener {
+            goToAlbum(requireActivity())
+        }
     }
 
     override fun onResume() {
@@ -81,7 +93,23 @@ class HomePlayerFragment : AbsPlayerFragment(R.layout.fragment_home_player),
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
     }
 
     override fun toolbarIconColor(): Int {

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/lockscreen/LockScreenControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/lockscreen/LockScreenControlsFragment.kt
@@ -31,6 +31,7 @@ import code.name.monkey.retromusic.extensions.textColorSecondary
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
 import com.google.android.material.slider.Slider
@@ -75,7 +76,9 @@ class LockScreenControlsFragment :
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = String.format("%s - %s", song.artistName, song.albumName)
+
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        binding.text.text = String.format("%s - %s", formattedArtistName, song.albumName)
     }
 
     override fun onServiceConnected() {

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/material/MaterialControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/material/MaterialControlsFragment.kt
@@ -20,18 +20,22 @@ import android.view.View
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentMaterialPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.slider.Slider
 
 /**
@@ -74,15 +78,28 @@ class MaterialControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/md3/MD3PlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/md3/MD3PlaybackControlsFragment.kt
@@ -18,20 +18,26 @@ import android.os.Bundle
 import android.view.View
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentMd3PlayerPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
 
 class MD3PlaybackControlsFragment :
@@ -77,9 +83,39 @@ class MD3PlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
+        
         binding.text.setOnClickListener {
-            goToArtist(requireActivity())
+            handleArtistClick()
         }
+    }
+    
+    private fun handleArtistClick() {
+        val activity = requireActivity() as? MainActivity ?: return
+        val song = MusicPlayerRemote.currentSong
+        val artistNames = ArtistSeparator.split(song.artistName)
+
+        if (artistNames.size > 1) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(getString(R.string.go_to_artist))
+                .setItems(artistNames.toTypedArray()) { _, which ->
+                    navigateToArtist(activity, artistNames[which])
+                }
+                .show()
+        } else if (artistNames.isNotEmpty()) {
+            navigateToArtist(activity, artistNames[0])
+        }
+    }
+
+    private fun navigateToArtist(activity: MainActivity, artistName: String) {
+        activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+        activity.setBottomNavVisibility(false)
+        if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+            activity.collapsePanel()
+        }
+        activity.findNavController(R.id.fragment_container).navigate(
+            R.id.artistDetailsFragment,
+            bundleOf(EXTRA_ARTIST_NAME to artistName)
+        )
     }
 
     override fun setColor(color: MediaNotificationProcessor) {
@@ -119,7 +155,7 @@ class MD3PlaybackControlsFragment :
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        binding.text.text = ArtistSeparator.split(song.artistName).joinToString(", ")
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/normal/PlayerPlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/normal/PlayerPlaybackControlsFragment.kt
@@ -19,19 +19,25 @@ import android.view.View
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentPlayerPlaybackControlsBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.slider.Slider
 
 class PlayerPlaybackControlsFragment :
@@ -71,9 +77,39 @@ class PlayerPlaybackControlsFragment :
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
+        
         binding.text.setOnClickListener {
-            goToArtist(requireActivity())
+            handleArtistClick()
         }
+    }
+    
+    private fun handleArtistClick() {
+        val activity = requireActivity() as? MainActivity ?: return
+        val song = MusicPlayerRemote.currentSong
+        val artistNames = ArtistSeparator.split(song.artistName)
+
+        if (artistNames.size > 1) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.go_to_artist)
+                .setItems(artistNames.toTypedArray()) { _, which ->
+                    navigateToArtist(activity, artistNames[which])
+                }
+                .show()
+        } else if (artistNames.isNotEmpty()) {
+            navigateToArtist(activity, artistNames[0])
+        }
+    }
+
+    private fun navigateToArtist(activity: MainActivity, artistName: String) {
+        activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+        activity.setBottomNavVisibility(false)
+        if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+            activity.collapsePanel()
+        }
+        activity.findNavController(R.id.fragment_container).navigate(
+            R.id.artistDetailsFragment,
+            bundleOf(EXTRA_ARTIST_NAME to artistName)
+        )
     }
 
     override fun setColor(color: MediaNotificationProcessor) {
@@ -115,7 +151,8 @@ class PlayerPlaybackControlsFragment :
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.text = ArtistSeparator.split(song.artistName).joinToString(", ")
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/peek/PeekPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/peek/PeekPlayerFragment.kt
@@ -17,17 +17,21 @@ package code.name.monkey.retromusic.fragments.player.peek
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentPeekPlayerBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 /**
  * Created by hemanths on 2019-10-03.
@@ -49,9 +53,6 @@ class PeekPlayerFragment : AbsPlayerFragment(R.layout.fragment_peek_player) {
         binding.title.isSelected = true
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
-        }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
         }
         binding.root.drawAboveSystemBarsWithPadding()
     }
@@ -105,7 +106,23 @@ class PeekPlayerFragment : AbsPlayerFragment(R.layout.fragment_peek_player) {
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/plain/PlainPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/plain/PlainPlayerFragment.kt
@@ -17,19 +17,21 @@ package code.name.monkey.retromusic.fragments.player.plain
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentPlainPlayerBinding
-import code.name.monkey.retromusic.extensions.colorControlNormal
-import code.name.monkey.retromusic.extensions.drawAboveSystemBars
-import code.name.monkey.retromusic.extensions.whichFragment
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 class PlainPlayerFragment : AbsPlayerFragment(R.layout.fragment_plain_player) {
     override fun playerToolbar(): Toolbar {
@@ -52,7 +54,23 @@ class PlainPlayerFragment : AbsPlayerFragment(R.layout.fragment_plain_player) {
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
     }
 
     override fun onServiceConnected() {
@@ -83,9 +101,7 @@ class PlainPlayerFragment : AbsPlayerFragment(R.layout.fragment_plain_player) {
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
+        
         playerToolbar().drawAboveSystemBars()
     }
 

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/simple/SimplePlaybackControlsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/simple/SimplePlaybackControlsFragment.kt
@@ -18,23 +18,24 @@ import android.os.Bundle
 import android.view.View
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageButton
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ATHUtil
 import code.name.monkey.appthemehelper.util.ColorUtil
 import code.name.monkey.appthemehelper.util.MaterialValueHelper
 import code.name.monkey.appthemehelper.util.TintHelper
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentSimpleControlsFragmentBinding
-import code.name.monkey.retromusic.extensions.accentColor
-import code.name.monkey.retromusic.extensions.getSongInfo
-import code.name.monkey.retromusic.extensions.hide
-import code.name.monkey.retromusic.extensions.show
+import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerControlsFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 
 /**
  * @author Hemanth S (h4h13).
@@ -82,22 +83,31 @@ class SimplePlaybackControlsFragment :
         _binding = FragmentSimpleControlsFragmentBinding.bind(view)
         setUpPlayPauseFab()
         binding.title.isSelected = true
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
-        }
-
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
-        }
-        binding.text.setOnClickListener {
-            goToArtist(requireActivity())
         }
     }
 
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = song.artistName
+        
+        binding.text.setArtistLinks(song.artistName) { artistName ->
+            
+      val activity = requireActivity()
+      if (activity is MainActivity) {
+          activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+          activity.setBottomNavVisibility(false)
+          if (activity.bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+              activity.collapsePanel()
+          }
+          activity.findNavController(R.id.fragment_container).navigate(
+              R.id.artistDetailsFragment,
+              bundleOf(EXTRA_ARTIST_NAME to artistName)
+          )
+      }
+    
+        }
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)
@@ -130,6 +140,7 @@ class SimplePlaybackControlsFragment :
     }
 
     override fun onUpdateProgressViews(progress: Int, total: Int) {
+        if (_binding == null) return
         binding.songCurrentProgress.text = String.format(
             "%s / %s",
             MusicUtil.getReadableDurationString(progress.toLong()),

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/tiny/TinyPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/tiny/TinyPlayerFragment.kt
@@ -25,23 +25,29 @@ import android.view.View
 import android.view.animation.LinearInterpolator
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.getSystemService
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import code.name.monkey.appthemehelper.util.ToolbarContentTintHelper
 import code.name.monkey.appthemehelper.util.VersionUtils
+import code.name.monkey.retromusic.EXTRA_ARTIST_NAME
 import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.activities.MainActivity
 import code.name.monkey.retromusic.databinding.FragmentTinyPlayerBinding
 import code.name.monkey.retromusic.extensions.*
 import code.name.monkey.retromusic.fragments.base.AbsPlayerFragment
 import code.name.monkey.retromusic.fragments.base.goToAlbum
-import code.name.monkey.retromusic.fragments.base.goToArtist
 import code.name.monkey.retromusic.fragments.player.PlayerAlbumCoverFragment
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.MusicProgressViewUpdateHelper
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.ViewUtil
 import code.name.monkey.retromusic.util.color.MediaNotificationProcessor
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlin.math.abs
 
 class TinyPlayerFragment : AbsPlayerFragment(R.layout.fragment_tiny_player),
@@ -116,7 +122,9 @@ class TinyPlayerFragment : AbsPlayerFragment(R.layout.fragment_tiny_player),
     private fun updateSong() {
         val song = MusicPlayerRemote.currentSong
         binding.title.text = song.title
-        binding.text.text = String.format("%s \nby - %s", song.albumName, song.artistName)
+        
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        binding.text.text = String.format("%s \nby - %s", song.albumName, formattedArtistName)
 
         if (PreferenceUtil.isSongInfo) {
             binding.songInfo.text = getSongInfo(song)
@@ -136,13 +144,44 @@ class TinyPlayerFragment : AbsPlayerFragment(R.layout.fragment_tiny_player),
 
         setUpPlayerToolbar()
         setUpSubFragments()
+        
         binding.title.setOnClickListener {
             goToAlbum(requireActivity())
         }
         binding.text.setOnClickListener {
-            goToArtist(requireActivity())
+            handleArtistClick()
         }
+        
         playerToolbar().drawAboveSystemBars()
+    }
+
+    private fun handleArtistClick() {
+        val activity = requireActivity() as? MainActivity ?: return
+        val song = MusicPlayerRemote.currentSong
+        val artistNames = ArtistSeparator.split(song.artistName)
+
+        if (artistNames.size > 1) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(getString(R.string.go_to_artist))
+                .setItems(artistNames.toTypedArray()) { _, which ->
+                    navigateToArtist(activity, artistNames[which])
+                }
+                .show()
+        } else if (artistNames.isNotEmpty()) {
+            navigateToArtist(activity, artistNames[0])
+        }
+    }
+    
+    private fun navigateToArtist(activity: MainActivity, artistName: String) {
+        activity.currentFragment(R.id.fragment_container)?.exitTransition = null
+        activity.setBottomNavVisibility(false)
+        if (activity.getBottomSheetBehavior().state == BottomSheetBehavior.STATE_EXPANDED) {
+            activity.collapsePanel()
+        }
+        activity.findNavController(R.id.fragment_container).navigate(
+            R.id.artistDetailsFragment,
+            bundleOf(EXTRA_ARTIST_NAME to artistName)
+        )
     }
 
     private fun setUpSubFragments() {
@@ -178,6 +217,7 @@ class TinyPlayerFragment : AbsPlayerFragment(R.layout.fragment_tiny_player),
     }
 
     override fun onUpdateProgressViews(progress: Int, total: Int) {
+        if (_binding == null) return
         binding.progressBar.max = total
 
         if (isDragEnabled) {

--- a/app/src/main/java/code/name/monkey/retromusic/interfaces/IArtistClickListener.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/interfaces/IArtistClickListener.kt
@@ -17,5 +17,5 @@ package code.name.monkey.retromusic.interfaces
 import android.view.View
 
 interface IArtistClickListener {
-    fun onArtist(artistId: Long, view: View)
+    fun onArtist(artistName: String, view: View)
 }

--- a/app/src/main/java/code/name/monkey/retromusic/model/Artist.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/model/Artist.kt
@@ -15,37 +15,15 @@
 package code.name.monkey.retromusic.model
 
 import code.name.monkey.retromusic.helper.SortOrder
-import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
 import java.text.Collator
 
 data class Artist(
     val id: Long,
     val albums: List<Album>,
-    val isAlbumArtist: Boolean = false
+    val isAlbumArtist: Boolean = false,
+    val name: String = albums.firstOrNull()?.let { if (isAlbumArtist) it.albumArtist else it.artistName } ?: "Unknown"
 ) {
-    constructor(
-        artistName: String,
-        albums: List<Album>,
-        isAlbumArtist: Boolean = false
-    ) : this(albums[0].artistId, albums, isAlbumArtist) {
-        name = artistName
-    }
-
-    var name: String = "-"
-        get() {
-            val name = if (isAlbumArtist) getAlbumArtistName()
-            else getArtistName()
-            return when {
-                MusicUtil.isVariousArtists(name) ->
-                    VARIOUS_ARTISTS_DISPLAY_NAME
-
-                MusicUtil.isArtistNameUnknown(name) ->
-                    UNKNOWN_ARTIST_DISPLAY_NAME
-
-                else -> name!!
-            }
-        }
 
     val songCount: Int
         get() {
@@ -65,82 +43,36 @@ data class Artist(
     val sortedSongs: List<Song>
         get() {
             val collator = Collator.getInstance()
-            return songs.sortedWith(
-                when (PreferenceUtil.artistDetailSongSortOrder) {
-                    SortOrder.ArtistSongSortOrder.SONG_A_Z -> { o1, o2 ->
-                        collator.compare(o1.title, o2.title)
-                    }
-
-                    SortOrder.ArtistSongSortOrder.SONG_Z_A -> { o1, o2 ->
-                        collator.compare(o2.title, o1.title)
-                    }
-
-                    SortOrder.ArtistSongSortOrder.SONG_ALBUM -> { o1, o2 ->
-                        collator.compare(o1.albumName, o2.albumName)
-                    }
-
-                    SortOrder.ArtistSongSortOrder.SONG_YEAR -> { o1, o2 ->
-                        o2.year.compareTo(
-                            o1.year
-                        )
-                    }
-
-                    SortOrder.ArtistSongSortOrder.SONG_DURATION -> { o1, o2 ->
-                        o1.duration.compareTo(
-                            o2.duration
-                        )
-                    }
-
-                    else -> {
-                        throw IllegalArgumentException("invalid ${PreferenceUtil.artistDetailSongSortOrder}")
-                    }
-                })
+            return when (PreferenceUtil.artistDetailSongSortOrder) {
+                SortOrder.ArtistSongSortOrder.SONG_A_Z -> songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
+                SortOrder.ArtistSongSortOrder.SONG_Z_A -> songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
+                SortOrder.ArtistSongSortOrder.SONG_ALBUM -> songs.sortedWith { o1, o2 -> collator.compare(o1.albumName, o2.albumName) }
+                SortOrder.ArtistSongSortOrder.SONG_YEAR -> songs.sortedByDescending { it.year }
+                SortOrder.ArtistSongSortOrder.SONG_DURATION -> songs.sortedBy { it.duration }
+                else -> songs.sortedBy { it.title } 
+            }
         }
 
     val sortedAlbums: List<Album>
         get() {
             val collator = Collator.getInstance()
-            return albums.sortedWith(
-                when (PreferenceUtil.artistAlbumSortOrder) {
-                    SortOrder.ArtistAlbumSortOrder.ALBUM_A_Z -> { o1, o2 ->
-                        collator.compare(o1.title, o2.title)
-                    }
-
-                    SortOrder.ArtistAlbumSortOrder.ALBUM_Z_A -> { o1, o2 ->
-                        collator.compare(o2.title, o1.title)
-                    }
-
-                    SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR_ASC -> { o1, o2 ->
-                        o1.year.compareTo(o2.year)
-                    }
-
-                    SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR -> { o1, o2 ->
-                        o2.year.compareTo(o1.year)
-                    }
-
-                    else -> {
-                        throw IllegalArgumentException("invalid ${PreferenceUtil.artistAlbumSortOrder}")
-                    }
-                })
+            return when (PreferenceUtil.artistAlbumSortOrder) {
+                SortOrder.ArtistAlbumSortOrder.ALBUM_A_Z -> albums.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
+                SortOrder.ArtistAlbumSortOrder.ALBUM_Z_A -> albums.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
+                SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR_ASC -> albums.sortedBy { it.year }
+                SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR -> albums.sortedByDescending { it.year }
+                else -> albums.sortedBy { it.title }
+            }
         }
 
     fun safeGetFirstAlbum(): Album {
         return albums.firstOrNull() ?: Album.empty
     }
 
-    private fun getArtistName(): String {
-        return safeGetFirstAlbum().safeGetFirstSong().artistName
-    }
-
-    private fun getAlbumArtistName(): String? {
-        return safeGetFirstAlbum().safeGetFirstSong().albumArtist
-    }
-
     companion object {
         const val UNKNOWN_ARTIST_DISPLAY_NAME = "Unknown Artist"
         const val VARIOUS_ARTISTS_DISPLAY_NAME = "Various Artists"
         const val VARIOUS_ARTISTS_ID: Long = -2
-        val empty = Artist(-1, emptyList())
-
+        val empty = Artist(-1, emptyList(), name = "")
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/AlbumRepository.kt
@@ -31,9 +31,11 @@ interface AlbumRepository {
     fun albums(query: String): List<Album>
 
     fun album(albumId: Long): Album
+    
+    fun splitIntoAlbums(songs: List<Song>): List<Album>
 }
 
-class RealAlbumRepository(private val songRepository: RealSongRepository) :
+class RealAlbumRepository(private val songRepository: SongRepository) :
     AlbumRepository {
 
     override fun albums(): List<Album> {
@@ -69,14 +71,8 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
         return sortAlbumSongs(album)
     }
 
-    // We don't need sorted list of songs (with sortAlbumSongs())
-    // cuz we are just displaying Albums(Cover Arts) anyway and not songs
-    fun splitIntoAlbums(
-        songs: List<Song>,
-        sorted: Boolean = true
-    ): List<Album> {
+    override fun splitIntoAlbums(songs: List<Song>): List<Album> {
         val grouped = songs.groupBy { it.albumId }.map { Album(it.key, it.value) }
-        if (!sorted) return grouped
         val collator = Collator.getInstance()
         return when (PreferenceUtil.albumSortOrder) {
             SortOrder.AlbumSortOrder.ALBUM_A_Z -> {
@@ -98,19 +94,11 @@ class RealAlbumRepository(private val songRepository: RealSongRepository) :
     private fun sortAlbumSongs(album: Album): Album {
         val collator = Collator.getInstance()
         val songs = when (PreferenceUtil.albumDetailSongSortOrder) {
-            SortOrder.AlbumSongSortOrder.SONG_TRACK_LIST -> album.songs.sortedWith { o1, o2 ->
-                o1.trackNumber.compareTo(o2.trackNumber)
-            }
-            SortOrder.AlbumSongSortOrder.SONG_A_Z -> {
-                album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
-            }
-            SortOrder.AlbumSongSortOrder.SONG_Z_A -> {
-                album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
-            }
-            SortOrder.AlbumSongSortOrder.SONG_DURATION -> album.songs.sortedWith { o1, o2 ->
-                o1.duration.compareTo(o2.duration)
-            }
-            else -> throw IllegalArgumentException("invalid ${PreferenceUtil.albumDetailSongSortOrder}")
+            SortOrder.AlbumSongSortOrder.SONG_TRACK_LIST -> album.songs.sortedBy { it.trackNumber }
+            SortOrder.AlbumSongSortOrder.SONG_A_Z -> album.songs.sortedWith { o1, o2 -> collator.compare(o1.title, o2.title) }
+            SortOrder.AlbumSongSortOrder.SONG_Z_A -> album.songs.sortedWith { o1, o2 -> collator.compare(o2.title, o1.title) }
+            SortOrder.AlbumSongSortOrder.SONG_DURATION -> album.songs.sortedBy { it.duration }
+            else -> album.songs.sortedBy { it.title } 
         }
         return album.copy(songs = songs)
     }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
@@ -19,6 +19,8 @@ import code.name.monkey.retromusic.ALBUM_ARTIST
 import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
+import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import java.text.Collator
 
@@ -34,11 +36,13 @@ interface ArtistRepository {
     fun artist(artistId: Long): Artist
 
     fun albumArtist(artistName: String): Artist
+    
+    fun artistByName(name: String): Artist
 }
 
 class RealArtistRepository(
-    private val songRepository: RealSongRepository,
-    private val albumRepository: RealAlbumRepository
+    private val songRepository: SongRepository, 
+    private val albumRepository: AlbumRepository
 ) : ArtistRepository {
 
     private fun getSongLoaderSortOrder(): String {
@@ -49,14 +53,7 @@ class RealArtistRepository(
 
     override fun artist(artistId: Long): Artist {
         if (artistId == Artist.VARIOUS_ARTISTS_ID) {
-            // Get Various Artists
-            val songs = songRepository.songs(
-                songRepository.makeSongCursor(
-                    null,
-                    null,
-                    getSongLoaderSortOrder()
-                )
-            )
+            val songs = songRepository.songs()
             val albums = albumRepository.splitIntoAlbums(songs)
                 .filter { it.albumArtist == Artist.VARIOUS_ARTISTS_DISPLAY_NAME }
             return Artist(Artist.VARIOUS_ARTISTS_ID, albums)
@@ -71,17 +68,22 @@ class RealArtistRepository(
         )
         return Artist(artistId, albumRepository.splitIntoAlbums(songs))
     }
+    
+    override fun artistByName(name: String): Artist {
+        val allSongs = songRepository.songs()
+
+        val songsForArtist = allSongs.filter { song ->
+            val sourceName = if (PreferenceUtil.albumArtistsOnly) song.albumArtist else song.artistName
+            ArtistSeparator.split(sourceName).any { it.equals(name, ignoreCase = true) }
+        }
+
+        val albums = albumRepository.splitIntoAlbums(songsForArtist)
+        return Artist(name.hashCode().toLong(), albums, name = name)
+    }
 
     override fun albumArtist(artistName: String): Artist {
         if (artistName == Artist.VARIOUS_ARTISTS_DISPLAY_NAME) {
-            // Get Various Artists
-            val songs = songRepository.songs(
-                songRepository.makeSongCursor(
-                    null,
-                    null,
-                    getSongLoaderSortOrder()
-                )
-            )
+            val songs = songRepository.songs()
             val albums = albumRepository.splitIntoAlbums(songs)
                 .filter { it.albumArtist == Artist.VARIOUS_ARTISTS_DISPLAY_NAME }
             return Artist(Artist.VARIOUS_ARTISTS_ID, albums, true)
@@ -94,81 +96,57 @@ class RealArtistRepository(
                 getSongLoaderSortOrder()
             )
         )
-        return Artist(artistName, albumRepository.splitIntoAlbums(songs), true)
+        return Artist(artistName.hashCode().toLong(), albumRepository.splitIntoAlbums(songs), true, name = artistName)
     }
 
     override fun artists(): List<Artist> {
-        val songs = songRepository.songs(
-            songRepository.makeSongCursor(
-                null, null,
-                getSongLoaderSortOrder()
-            )
-        )
-        val artists = splitIntoArtists(albumRepository.splitIntoAlbums(songs))
-        return sortArtists(artists)
+        val songs = songRepository.songs()
+        val artistToSongsMap = mutableMapOf<String, MutableList<Song>>()
+
+        songs.forEach { song ->
+            ArtistSeparator.split(song.artistName).forEach { name ->
+                val trimmedName = name.trim()
+                if (trimmedName.isNotEmpty()) {
+                    artistToSongsMap.getOrPut(trimmedName) { mutableListOf() }.add(song)
+                }
+            }
+        }
+
+        val processedArtists = artistToSongsMap.map { (artistName, songsForArtist) ->
+            val albums = albumRepository.splitIntoAlbums(songsForArtist)
+            Artist(artistName.hashCode().toLong(), albums, name = artistName)
+        }
+
+        return sortArtists(processedArtists)
     }
 
     override fun albumArtists(): List<Artist> {
-        val songs = songRepository.songs(
-            songRepository.makeSongCursor(
-                null,
-                null,
-                "lower($ALBUM_ARTIST)" +
-                        if (PreferenceUtil.artistSortOrder == SortOrder.ArtistSortOrder.ARTIST_A_Z) "" else " DESC"
-            )
-        )
-        val artists = splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
-        return sortArtists(artists)
+        val songs = songRepository.songs()
+        val artistToSongsMap = mutableMapOf<String, MutableList<Song>>()
+
+        songs.forEach { song ->
+            ArtistSeparator.split(song.albumArtist).forEach { name ->
+                val trimmedName = name.trim()
+                if (trimmedName.isNotEmpty()) {
+                    artistToSongsMap.getOrPut(trimmedName) { mutableListOf() }.add(song)
+                }
+            }
+        }
+
+        val processedArtists = artistToSongsMap.map { (artistName, songsForArtist) ->
+            val albums = albumRepository.splitIntoAlbums(songsForArtist)
+            Artist(artistName.hashCode().toLong(), albums, isAlbumArtist = true, name = artistName)
+        }
+        
+        return sortArtists(processedArtists)
     }
 
     override fun albumArtists(query: String): List<Artist> {
-        val songs = songRepository.songs(
-            songRepository.makeSongCursor(
-                "album_artist" + " LIKE ?",
-                arrayOf("%$query%"),
-                getSongLoaderSortOrder()
-            )
-        )
-        val artists = splitIntoAlbumArtists(albumRepository.splitIntoAlbums(songs))
-        return sortArtists(artists)
+        return albumArtists().filter { it.name.contains(query, ignoreCase = true) }
     }
 
     override fun artists(query: String): List<Artist> {
-        val songs = songRepository.songs(
-            songRepository.makeSongCursor(
-                AudioColumns.ARTIST + " LIKE ?",
-                arrayOf("%$query%"),
-                getSongLoaderSortOrder()
-            )
-        )
-        val artists = splitIntoArtists(albumRepository.splitIntoAlbums(songs))
-        return sortArtists(artists)
-    }
-
-
-    private fun splitIntoAlbumArtists(albums: List<Album>): List<Artist> {
-        return albums.groupBy { it.albumArtist }
-            .filter {
-                !it.key.isNullOrEmpty()
-            }
-            .map {
-                val currentAlbums = it.value
-                if (currentAlbums.isNotEmpty()) {
-                    if (currentAlbums[0].albumArtist == Artist.VARIOUS_ARTISTS_DISPLAY_NAME) {
-                        Artist(Artist.VARIOUS_ARTISTS_ID, currentAlbums, true)
-                    } else {
-                        Artist(currentAlbums[0].artistId, currentAlbums, true)
-                    }
-                } else {
-                    Artist.empty
-                }
-            }
-    }
-
-
-    fun splitIntoArtists(albums: List<Album>): List<Artist> {
-        return albums.groupBy { it.artistId }
-            .map { Artist(it.key, it.value) }
+        return artists().filter { it.name.contains(query, ignoreCase = true) }
     }
 
     private fun sortArtists(artists: List<Artist>): List<Artist> {

--- a/app/src/main/java/code/name/monkey/retromusic/repository/LastAddedSongsRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/LastAddedSongsRepository.kt
@@ -19,6 +19,7 @@ import android.provider.MediaStore
 import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 
 /**
@@ -33,20 +34,34 @@ interface LastAddedRepository {
 }
 
 class RealLastAddedRepository(
-    private val songRepository: RealSongRepository,
-    private val albumRepository: RealAlbumRepository,
-    private val artistRepository: RealArtistRepository
+    private val songRepository: SongRepository,
+    private val albumRepository: AlbumRepository,
+    private val artistRepository: ArtistRepository
 ) : LastAddedRepository {
     override fun recentSongs(): List<Song> {
         return songRepository.songs(makeLastAddedCursor())
     }
 
     override fun recentAlbums(): List<Album> {
-        return albumRepository.splitIntoAlbums(recentSongs(), sorted = false)
+        return albumRepository.splitIntoAlbums(recentSongs())
     }
 
     override fun recentArtists(): List<Artist> {
-        return artistRepository.splitIntoArtists(recentAlbums())
+        val recentSongs = recentSongs()
+        val artistNames = mutableSetOf<String>()
+
+        recentSongs.forEach { song ->
+            val sourceName = if (PreferenceUtil.albumArtistsOnly) song.albumArtist else song.artistName
+            ArtistSeparator.split(sourceName).forEach { name ->
+                val trimmedName = name.trim()
+                if (trimmedName.isNotEmpty()) {
+                    artistNames.add(trimmedName)
+                }
+            }
+        }
+        
+        val allArtists = if (PreferenceUtil.albumArtistsOnly) artistRepository.albumArtists() else artistRepository.artists()
+        return allArtists.filter { artist -> artistNames.contains(artist.name) }
     }
 
     private fun makeLastAddedCursor(): Cursor? {

--- a/app/src/main/java/code/name/monkey/retromusic/repository/Repository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/Repository.kt
@@ -97,6 +97,8 @@ interface Repository {
     fun getSongByGenre(genreId: Long): Song
     fun checkPlaylistExists(playListId: Long): LiveData<Boolean>
     fun getPlaylist(playlistId: Long): LiveData<PlaylistWithSongs>
+
+    suspend fun artistByName(name: String): Artist
 }
 
 class RealRepository(
@@ -113,6 +115,8 @@ class RealRepository(
     private val roomRepository: RoomRepository,
     private val localDataRepository: LocalDataRepository,
 ) : Repository {
+
+    override suspend fun artistByName(name: String): Artist = artistRepository.artistByName(name)
 
     override suspend fun deleteSongs(songs: List<Song>) = roomRepository.deleteSongs(songs)
 

--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -53,6 +53,12 @@ interface SongRepository {
     fun song(cursor: Cursor?): Song
 
     fun song(songId: Long): Song
+    fun makeSongCursor(
+        selection: String?,
+        selectionValues: Array<String>?,
+        sortOrder: String = PreferenceUtil.songSortOrder,
+        ignoreBlacklist: Boolean = false
+    ): Cursor?
 }
 
 class RealSongRepository(private val context: Context) : SongRepository {
@@ -160,11 +166,11 @@ class RealSongRepository(private val context: Context) : SongRepository {
     }
 
     @JvmOverloads
-    fun makeSongCursor(
+    override fun makeSongCursor(
         selection: String?,
         selectionValues: Array<String>?,
-        sortOrder: String = PreferenceUtil.songSortOrder,
-        ignoreBlacklist: Boolean = false
+        sortOrder: String,
+        ignoreBlacklist: Boolean
     ): Cursor? {
         var selectionFinal = selection
         var selectionValuesFinal = selectionValues

--- a/app/src/main/java/code/name/monkey/retromusic/repository/TopPlayedRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/TopPlayedRepository.kt
@@ -24,7 +24,9 @@ import code.name.monkey.retromusic.model.Artist
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.providers.HistoryStore
 import code.name.monkey.retromusic.providers.SongPlayCountStore
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
+import kotlinx.coroutines.runBlocking
 
 
 /**
@@ -33,21 +35,17 @@ import code.name.monkey.retromusic.util.PreferenceUtil
 
 interface TopPlayedRepository {
     fun recentlyPlayedTracks(): List<Song>
-
     fun topTracks(): List<Song>
-
     fun notRecentlyPlayedTracks(): List<Song>
-
     fun topAlbums(): List<Album>
-
     fun topArtists(): List<Artist>
 }
 
 class RealTopPlayedRepository(
     private val context: Context,
-    private val songRepository: RealSongRepository,
-    private val albumRepository: RealAlbumRepository,
-    private val artistRepository: RealArtistRepository
+    private val songRepository: SongRepository,
+    private val albumRepository: AlbumRepository,
+    private val artistRepository: ArtistRepository
 ) : TopPlayedRepository {
 
     override fun recentlyPlayedTracks(): List<Song> {
@@ -59,16 +57,12 @@ class RealTopPlayedRepository(
     }
 
     override fun notRecentlyPlayedTracks(): List<Song> {
-        val allSongs = mutableListOf<Song>().apply {
-            addAll(
-                songRepository.songs(
-                    songRepository.makeSongCursor(
-                        null, null,
-                        MediaStore.Audio.Media.DATE_ADDED + " ASC"
-                    )
-                )
+        val allSongs = songRepository.songs(
+            songRepository.makeSongCursor(
+                null, null,
+                MediaStore.Audio.Media.DATE_ADDED + " ASC"
             )
-        }
+        ).toMutableList()
         val playedSongs = songRepository.songs(
             makePlayedTracksCursorAndClearUpDatabase()
         )
@@ -81,11 +75,25 @@ class RealTopPlayedRepository(
     }
 
     override fun topAlbums(): List<Album> {
-        return albumRepository.splitIntoAlbums(topTracks(), sorted = false)
+        return albumRepository.splitIntoAlbums(runBlocking { topTracks() })
     }
 
     override fun topArtists(): List<Artist> {
-        return artistRepository.splitIntoArtists(topAlbums())
+        val topSongs = topTracks()
+        val artistNames = mutableSetOf<String>()
+
+        topSongs.forEach { song ->
+            val sourceName = if (PreferenceUtil.albumArtistsOnly) song.albumArtist else song.artistName
+            ArtistSeparator.split(sourceName).forEach { name ->
+                val trimmedName = name.trim()
+                if (trimmedName.isNotEmpty()) {
+                    artistNames.add(trimmedName)
+                }
+            }
+        }
+
+        val allArtists = if (PreferenceUtil.albumArtistsOnly) artistRepository.albumArtists() else artistRepository.artists()
+        return allArtists.filter { artist -> artistNames.contains(artist.name) }
     }
 
 
@@ -94,7 +102,7 @@ class RealTopPlayedRepository(
         // clean up the databases with any ids not found
         if (retCursor != null) {
             val missingIds = retCursor.missingIds
-            if (missingIds != null && missingIds.size > 0) {
+            if (missingIds != null && missingIds.isNotEmpty()) {
                 for (id in missingIds) {
                     SongPlayCountStore.getInstance(context).removeItem(id)
                 }
@@ -196,10 +204,9 @@ class RealTopPlayedRepository(
     ): SortedLongCursor? {
         val retCursor = makeRecentTracksCursorImpl(ignoreCutoffTime, reverseOrder)
         // clean up the databases with any ids not found
-        // clean up the databases with any ids not found
         if (retCursor != null) {
             val missingIds = retCursor.missingIds
-            if (missingIds != null && missingIds.size > 0) {
+            if (missingIds != null && missingIds.isNotEmpty()) {
                 for (id in missingIds) {
                     HistoryStore.getInstance(context).removeSongId(id)
                 }

--- a/app/src/main/java/code/name/monkey/retromusic/service/notification/PlayingNotification.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/notification/PlayingNotification.kt
@@ -40,6 +40,7 @@ import code.name.monkey.retromusic.service.MusicService.Companion.ACTION_REWIND
 import code.name.monkey.retromusic.service.MusicService.Companion.ACTION_SKIP
 import code.name.monkey.retromusic.service.MusicService.Companion.ACTION_TOGGLE_PAUSE
 import code.name.monkey.retromusic.service.MusicService.Companion.TOGGLE_FAVORITE
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
@@ -112,13 +113,14 @@ class PlayingNotification(
 
     fun updateMetadata(song: Song, onUpdate: () -> Unit) {
         if (song == Song.emptySong) return
+        
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        
         setContentTitle(song.title)
-        setContentText(song.artistName)
+        setContentText(formattedArtistName)
         setSubText(song.albumName)
 
         // Displays a temporary image while Glide loads the actual album image.
-        // This allows us to update the notification immediately
-        // without waiting for Glide.
         setAlbumArtImage(null)
         onUpdate()
 
@@ -129,7 +131,6 @@ class PlayingNotification(
             .asBitmap()
             .songCoverOptions(song)
             .load(RetroGlideExtension.getSongModel(song))
-            //.checkIgnoreMediaStore()
             .centerCrop()
             .into(object : CustomTarget<Bitmap>(
                 bigNotificationImageSize,

--- a/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
@@ -1,0 +1,19 @@
+package code.name.monkey.retromusic.util
+
+object ArtistSeparator {
+
+    val SEPARATORS: Array<String> = arrayOf("/", ";", ",", "feat.", "ft.")
+
+    private val regex = SEPARATORS.joinToString("|") { Regex.escape(it) }.toRegex(RegexOption.IGNORE_CASE)
+
+    fun split(artistString: String?): List<String> {
+        if (artistString.isNullOrEmpty()) {
+            return emptyList()
+        }
+
+        return artistString.split(regex)
+            .map { it.trim() } 
+            .filter { it.isNotEmpty() } 
+            .distinct() 
+    }
+}

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -41,7 +41,13 @@
         tools:layout="@layout/fragment_artist_details">
         <argument
             android:name="extra_artist_id"
-            app:argType="long" />
+            app:argType="long"
+            android:defaultValue="-1L" />
+        <argument
+            android:name="extra_artist_name"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -570,5 +570,7 @@
     <string name="scan_complete">Scan complete: %1$d media items found.</string>
     <string name="pref_save_last_directory_summary">When switching to folder view, restore last used directory</string>
     <string name="pref_save_last_directory_title">Save Last Directory</string>
+    <string name="go_to_artist">Go to artist</string>
+    <string name="artist_separator_helper_text">To add multiple artists, separate them with: %1$s</string>
 
 </resources>


### PR DESCRIPTION
#### Summary

*   Adds `ArtistSeparator` utility and uses it across UI and repositories to support multi-artist names and formatted display.
*   Switches artist navigation and callbacks from ID-based to name-based (`IArtistClickListener`), enabling navigation by artist name and shared-element transitions by name.
*   Adds name-based lookup paths (`artistByName`) and adapts repositories/viewmodels to resolve artists by name, with a fallback to ID-based lookups.
*   Replaces many fragile direct imports with grouped imports where appropriate and tidies up existing ones.
*   Improves null-safety and lifecycle checks across fragments and adapters (e.g., `isAdded`, nullable models, `let` guards).
*   Replaces verbose custom sort implementations with idiomatic `sortedBy`/`sortedByDescending`/`sortedWith` where applicable.
*   Makes access-level adjustments (e.g., `bottomSheetBehavior` made `internal`) to reduce accidental misuse while enabling necessary access.
*   Replaces the global `goToArtist` helper with robust, inline navigation logic that handles multi-artist selection (via dialog) and safely manages BottomSheet/backstack state.
*   Guards Glide image loads with lifecycle checks (e.g., `isDestroyed`) to prevent crashes and fixes minor UI/formatting issues.
*   **Note:** The `MediaSession` metadata for notifications was not updated to reflect formatted artist names, as it would require changing `private` access modifiers in `MusicService`. 

#### Per-file highlights

*   **`AbsSlidingMusicPanelActivity.kt`** — Imports cleanup; `bottomSheetBehavior` made `internal`; `navigationBarColor` made `protected`.
*   **`SongTagEditorActivity.kt`** — Displays artist-separator helper text to guide users; guards Glide load with `isDestroyed` check.
*   **UI Adapters** (`HomeAdapter.kt`, `SearchAdapter.kt`, `ArtistAdapter.kt`, `SongAdapter.kt`) — Display artist names formatted via `ArtistSeparator`; navigation and transitions now use artist name strings.
*   **App Components** (`BaseAppWidget.kt`, `AutoMusicProvider.kt`) — Display artist names formatted via `ArtistSeparator`.
*   **`PlayingNotification.kt`** — Formats the visible artist name in the notification text. A `TODO` was added to address the `MediaSession` metadata update, which is out of scope.
*   **Player UI fragments** (`BlurPlaybackControlsFragment`, `CardPlaybackControlsFragment`, `ClassicPlayerFragment`, `FullPlayerFragment`, etc.) — Replaced `setArtistLinks` with a more stable `MaterialAlertDialog` for multi-artist selection in themes where link implementation was causing UI bugs (`Blur`, `Tiny`). Maintained `setArtistLinks` in stable themes. Added MainActivity checks, BottomSheet collapse handling, `onBackPressed` lifecycle guards, and multi-artist selection dialogs where needed.
*   **`IArtistClickListener.kt`** — Callback signature changed from `onArtist(artistId: Long)` → `onArtist(artistName: String)`.
*   **`Artist.kt`** — Model refactored: `name` is now a primary constructor property, sorting logic and defaults are simplified, and the baseline empty artist case is improved.
*   **Repositories** (`AlbumRepository`, `ArtistRepository`, `LastAddedSongsRepository`, `TopPlayedRepository`, `SongRepository`, `Repository.kt`) — Introduced `SongRepository`/`AlbumRepository` interface usage, added `artistByName` methods, and moved to name-aware grouping. Replaced many SQL cursor code paths with `songRepository.songs()` accessors for in-memory processing and simplified sorting fallbacks.
*   **ViewModels & Fragments** (`LibraryViewModel.kt`, `ArtistDetailsViewModel.kt`, `AlbumDetailsFragment.kt`, etc.) — Support for `extra_artist_name` navigation argument, preferring name for lookups when provided. Added `artistByName` LiveData helpers and improved null-safety with nullable models and safe calls.
*   **Navigation/Resources** — Added `extra_artist_name` nav argument to the navigation graph and `go_to_artist`/helper text strings to `strings.xml`.

#### CHANGELOG
*   Improvements: Safer lifecycle handling, multi-artist parsing & clickable artist links, name-based navigation, and simplified repository refactors.

#### Quick PR Checklist
- [x] Build succeeds and basic flows tested (open player, open artist, navigate).
- [x] Multi-artist tracks tested for selection and navigation.
- [x] Verify shared-element transitions for artist images still work.