### PR TITLE
Fix #1955 : Now songs are cleared immediately from most played list if deleted 

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/dialogs/DeleteSongsDialog.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/dialogs/DeleteSongsDialog.kt
@@ -166,5 +166,6 @@ class DeleteSongsDialog : DialogFragment() {
         libraryViewModel.forceReload(ReloadType.HomeSections)
         libraryViewModel.forceReload(ReloadType.Artists)
         libraryViewModel.forceReload(ReloadType.Albums)
+        libraryViewModel.forceReload(ReloadType.PlayCount)
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
@@ -53,6 +53,7 @@ class LibraryViewModel(
     private val searchResults = MutableLiveData<List<Any>>()
     private val fabMargin = MutableLiveData(0)
     private val songHistory = MutableLiveData<List<Song>>()
+    private val playCountSongsData = MutableLiveData<List<Song>>()
     private var previousSongHistory = ArrayList<HistoryEntity>()
     val paletteColor: LiveData<Int> = _paletteColor
 
@@ -139,6 +140,7 @@ class LibraryViewModel(
             Playlists -> fetchPlaylists()
             Genres -> fetchGenres()
             Suggestions -> fetchSuggestions()
+            PlayCount -> fetchPlayCountSongs()
         }
     }
 
@@ -250,13 +252,22 @@ class LibraryViewModel(
         emit(repository.recentSongs())
     }
 
-    fun playCountSongs(): LiveData<List<Song>> = liveData(IO) {
+    fun playCountSongs(): LiveData<List<Song>> {
+        if (playCountSongsData.value == null) {
+            viewModelScope.launch(IO) {
+                fetchPlayCountSongs()
+            }
+        }
+        return playCountSongsData
+    }
+
+    private suspend fun fetchPlayCountSongs() {
         repository.playCountSongs().forEach { song ->
             if (!File(song.data).exists() || song.id == -1L) {
                 repository.deleteSongInPlayCount(song)
             }
         }
-        emit(repository.playCountSongs().map {
+        playCountSongsData.postValue(repository.playCountSongs().map {
             it.toSong()
         })
     }
@@ -391,5 +402,6 @@ enum class ReloadType {
     HomeSections,
     Playlists,
     Genres,
-    Suggestions
+    Suggestions,
+    PlayCount
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -125,7 +125,9 @@
         <item>System default</item>
         <item>Arabic</item>
         <item>Basque</item>
+        <item>Bulgarian</item>
         <item>Burmese</item>
+        <item>Catalan</item>
         <item>Simplified Chinese</item>
         <item>Traditional Chinese(Hong Kong)</item>
         <item>Traditional Chinese(Taiwan)</item>
@@ -148,6 +150,7 @@
         <item>Kurmanji Kurdish</item>
         <item>Latvian</item>
         <item>Malayalam</item>
+        <item>Odia</item>
         <item>Persian</item>
         <item>Polish</item>
         <item>Portuguese(Brazil)</item>
@@ -155,6 +158,7 @@
         <item>Romanian</item>
         <item>Russian</item>
         <item>Serbian</item>
+        <item>Sorani Kurdish</item>
         <item>Spanish</item>
         <item>Spanish(Latin America)</item>
         <item>Swedish</item>
@@ -169,7 +173,9 @@
         <item>auto</item>
         <item>ar-SA</item>
         <item>eu-ES</item>
+        <item>bg-BG</item>
         <item>my-MM</item>
+        <item>ca-ES</item>
         <item>zh-CN</item>
         <item>zh-HK</item>
         <item>zh-TW</item>
@@ -192,6 +198,7 @@
         <item>kmr-TR</item>
         <item>lv-LV</item>
         <item>ml</item>
+        <item>or-IN</item>
         <item>fa</item>
         <item>pl</item>
         <item>pt-BR</item>
@@ -199,6 +206,7 @@
         <item>ro</item>
         <item>ru</item>
         <item>sr</item>
+        <item>ckb-IR</item>
         <item>es</item>
         <item>es-419</item>
         <item>sv</item>


### PR DESCRIPTION
When a song is deleted, the play count data is NOT being reloaded. The playCountSongs() function in LibraryViewModel returns a liveData that only emits once when first observed, and there's no mechanism to trigger a refresh when songs are deleted.

I made three key changes:

1. Added PlayCount to ReloadType enum (LibraryViewModel.kt)
Added a new reload type to handle play count data refreshes

2. Converted playCountSongs() to use MutableLiveData (LibraryViewModel.kt)
Changed from liveData {} builder to MutableLiveData with a separate fetchPlayCountSongs() method
This allows the data to be refreshed on demand via forceReload()
The cleanup logic (removing invalid songs) now runs every time data is fetched

3. Updated DeleteSongsDialog.reloadTabs() (DeleteSongsDialog.kt)
Added libraryViewModel.forceReload(ReloadType.PlayCount) to trigger a refresh of Most Played data when songs are deleted