### PR TITLE
Fixing #1955

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/dialogs/DeleteSongsDialog.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/dialogs/DeleteSongsDialog.kt
@@ -166,5 +166,6 @@ class DeleteSongsDialog : DialogFragment() {
         libraryViewModel.forceReload(ReloadType.HomeSections)
         libraryViewModel.forceReload(ReloadType.Artists)
         libraryViewModel.forceReload(ReloadType.Albums)
+        libraryViewModel.forceReload(ReloadType.PlayCount)
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
@@ -53,6 +53,7 @@ class LibraryViewModel(
     private val searchResults = MutableLiveData<List<Any>>()
     private val fabMargin = MutableLiveData(0)
     private val songHistory = MutableLiveData<List<Song>>()
+    private val playCountSongsData = MutableLiveData<List<Song>>()
     private var previousSongHistory = ArrayList<HistoryEntity>()
     val paletteColor: LiveData<Int> = _paletteColor
 
@@ -139,6 +140,7 @@ class LibraryViewModel(
             Playlists -> fetchPlaylists()
             Genres -> fetchGenres()
             Suggestions -> fetchSuggestions()
+            PlayCount -> fetchPlayCountSongs()
         }
     }
 
@@ -250,13 +252,22 @@ class LibraryViewModel(
         emit(repository.recentSongs())
     }
 
-    fun playCountSongs(): LiveData<List<Song>> = liveData(IO) {
+    fun playCountSongs(): LiveData<List<Song>> {
+        if (playCountSongsData.value == null) {
+            viewModelScope.launch(IO) {
+                fetchPlayCountSongs()
+            }
+        }
+        return playCountSongsData
+    }
+
+    private suspend fun fetchPlayCountSongs() {
         repository.playCountSongs().forEach { song ->
             if (!File(song.data).exists() || song.id == -1L) {
                 repository.deleteSongInPlayCount(song)
             }
         }
-        emit(repository.playCountSongs().map {
+        playCountSongsData.postValue(repository.playCountSongs().map {
             it.toSong()
         })
     }
@@ -391,5 +402,6 @@ enum class ReloadType {
     HomeSections,
     Playlists,
     Genres,
-    Suggestions
+    Suggestions,
+    PlayCount
 }


### PR DESCRIPTION
When a song is deleted, the play count data is NOT being reloaded. The playCountSongs() function in LibraryViewModel returns a liveData that only emits once when first observed, and there's no mechanism to trigger a refresh when songs are deleted.

I made three key changes:

Added PlayCount to ReloadType enum (LibraryViewModel.kt)
Added a new reload type to handle play count data refreshes

Converted playCountSongs() to use MutableLiveData (LibraryViewModel.kt)
Changed from liveData {} builder to MutableLiveData with a separate fetchPlayCountSongs() method
This allows the data to be refreshed on demand via forceReload()
The cleanup logic (removing invalid songs) now runs every time data is fetched

Updated DeleteSongsDialog.reloadTabs() (DeleteSongsDialog.kt)
Added libraryViewModel.forceReload(ReloadType.PlayCount) to trigger a refresh of Most Played data when songs are deleted