### PR TITLE
fix #645 searching at accents and diacritics

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -34,6 +34,7 @@ import code.name.monkey.retromusic.providers.BlacklistStore
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.getExternalStoragePublicDirectory
 import java.text.Collator
+import java.text.Normalizer
 
 /**
  * Created by hemanths on 10/08/17.
@@ -251,7 +252,7 @@ class RealSongRepository(private val context: Context) : SongRepository {
     }
 
     private fun String.convertUnaccentText(): String {
-        val temp = java.text.Normalizer.normalize(this, java.text.Normalizer.Form.NFD)
+        val temp = Normalizer.normalize(this, Normalizer.Form.NFD)
         return "\\p{InCombiningDiacriticalMarks}+".toRegex().replace(temp, "")
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -251,8 +251,12 @@ class RealSongRepository(private val context: Context) : SongRepository {
         return newSelectionValues
     }
 
+    private val convertedUnaccentTextCache = mutableMapOf<String, String>()
+
     private fun String.convertUnaccentText(): String {
-        val temp = Normalizer.normalize(this, Normalizer.Form.NFD)
-        return "\\p{InCombiningDiacriticalMarks}+".toRegex().replace(temp, "")
+        return convertedUnaccentTextCache.getOrPut(this) {
+            val temp = Normalizer.normalize(this, Normalizer.Form.NFD)
+            "\\p{InCombiningDiacriticalMarks}+".toRegex().replace(temp, "")
+        }
     }
 }

--- a/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SongRepository.kt
@@ -109,7 +109,12 @@ class RealSongRepository(private val context: Context) : SongRepository {
     }
 
     override fun songs(query: String): List<Song> {
-        return songs(makeSongCursor(AudioColumns.TITLE + " LIKE ?", arrayOf("%$query%")))
+        val unaccentedQuery = query.convertUnaccentText()
+        return songs().filter {
+            it.title.convertUnaccentText().contains(unaccentedQuery, ignoreCase = true) ||
+                    it.artistName.convertUnaccentText().contains(unaccentedQuery, ignoreCase = true) ||
+                    it.albumName.convertUnaccentText().contains(unaccentedQuery, ignoreCase = true)
+        }
     }
 
     override fun song(songId: Long): Song {
@@ -243,5 +248,10 @@ class RealSongRepository(private val context: Context) : SongRepository {
             newSelectionValues[i] = paths[i - selectionValuesFinal.size] + "%"
         }
         return newSelectionValues
+    }
+
+    private fun String.convertUnaccentText(): String {
+        val temp = java.text.Normalizer.normalize(this, java.text.Normalizer.Form.NFD)
+        return "\\p{InCombiningDiacriticalMarks}+".toRegex().replace(temp, "")
     }
 }


### PR DESCRIPTION
This PR addresses #645 by improving the search logic to handle accented characters (diacritics). Previously, searching for terms like "lumie" would not match "lumière". I have updated the search filter to be more flexible, allowing users to find results even without typing exact accents.

## Changes:

Normalizes search queries and target strings to ignore diacritics.

## Screenshots:
 | Before (Exact match only) | After (Fuzzy match enabled) |
 | :--- | :--- | 
| <img width="1080" height="2340" alt="Screenshot_20260128-210926" src="https://github.com/user-attachments/assets/85e4ed4b-b8ff-4978-97c7-a03da3532ab0" /> | <img width="1080" height="2340" alt="Screenshot_20260128-210848" src="https://github.com/user-attachments/assets/14219f6e-e59c-445b-9a00-13eadd1b1d2b" /> |
 | Searching "lumie" returns no results. | Searching "lumie" correctly displays "lumière". |