### PR TITLE
feature: Disable internal speaker option

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/service/PlaybackManager.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/PlaybackManager.kt
@@ -3,7 +3,11 @@ package code.name.monkey.retromusic.service
 import android.content.Context
 import android.content.Intent
 import android.media.audiofx.AudioEffect
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
 import android.net.Uri
+import code.name.monkey.retromusic.R
+import code.name.monkey.retromusic.extensions.showToast
 import code.name.monkey.retromusic.model.Song
 import code.name.monkey.retromusic.service.playback.Playback
 import code.name.monkey.retromusic.util.PreferenceUtil
@@ -34,6 +38,8 @@ class PlaybackManager(val context: Context) {
     val isPlaying: Boolean
         get() = playback != null && playback!!.isPlaying
 
+    private val audioManager: AudioManager = context.getSystemService(AudioManager::class.java)
+
     init {
         playback = createLocalPlayback()
     }
@@ -43,6 +49,10 @@ class PlaybackManager(val context: Context) {
     }
 
     fun play(onNotInitialized: () -> Unit) {
+        if (PreferenceUtil.isSpeakerDisabled && speakerEnabled()) {
+            context.showToast(R.string.speaker_disabled)
+            return
+        }
         if (playback != null && !playback!!.isPlaying) {
             if (!playback!!.isInitialized) {
                 onNotInitialized()
@@ -182,6 +192,26 @@ class PlaybackManager(val context: Context) {
 
     fun setPlaybackSpeedPitch(playbackSpeed: Float, playbackPitch: Float) {
         playback?.setPlaybackSpeedPitch(playbackSpeed, playbackPitch)
+    }
+
+    private fun speakerEnabled(): Boolean {
+        val headsetTypes = setOf(
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            AudioDeviceInfo.TYPE_BLE_HEADSET,
+            AudioDeviceInfo.TYPE_BLE_SPEAKER,
+            AudioDeviceInfo.TYPE_WIRED_HEADSET,
+            AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+            AudioDeviceInfo.TYPE_USB_HEADSET,
+            AudioDeviceInfo.TYPE_USB_DEVICE
+        )
+        val devices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        for (device in devices) {
+            if (device.type in headsetTypes) {
+                return false
+            }
+        }
+        return true
     }
 }
 

--- a/app/src/main/java/code/name/monkey/retromusic/util/PreferenceUtil.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/PreferenceUtil.kt
@@ -390,6 +390,8 @@ object PreferenceUtil {
             BLUETOOTH_PLAYBACK, false
         )
 
+    val isSpeakerDisabled get() = sharedPreferences.getBoolean("disable_speaker", false)
+
     val isBlurredAlbumArt
         get() = sharedPreferences.getBoolean(
             BLURRED_ALBUM_ART, false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
     <string name="pref_summary_colored_notification">"Colors the notification in the album cover\u2019s vibrant color"</string>
     <string name="pref_summary_cross_fade">Duration to crossfade between songs</string>
     <string name="pref_summary_desaturated_color">As per Material Design guide lines in dark mode colors should be desaturated</string>
+    <string name="pref_summary_disable_speaker">Disable playback from the internal speaker</string>
     <string name="pref_summary_expand_now_playing_panel">Clicking on the notification will show now playing screen instead of the home screen</string>
     <string name="pref_summary_extra_controls">Add extra controls for mini player</string>
     <string name="pref_summary_extra_song_info">Show extra Song information, such as file format, bitrate and frequency</string>
@@ -391,6 +392,7 @@
     <string name="pref_title_cross_fade">Crossfade (Beta)</string>
     <string name="pref_title_custom_font">Use Manrope font</string>
     <string name="pref_title_desaturated_color">Desaturated color</string>
+    <string name="pref_title_disable_speaker">Disable internal speaker</string>
     <string name="pref_title_expand_now_playing_panel">Show now playing screen</string>
     <string name="pref_title_extra_controls">Extra controls</string>
     <string name="pref_title_extra_song_info">Song info</string>
@@ -509,6 +511,7 @@
     <string name="sort_order_year_asc">Year ascending</string>
     <string name="sort_order_year_desc">Year descending</string>
     <string name="sort_order_z_a">Descending</string>
+    <string name="speaker_disabled">Internal speaker playback is disabled</string>
     <string name="speech_not_supported">Sorry! Your device doesn\'t support speech input</string>
     <string name="speech_prompt">Search your library</string>
     <string name="stack">Stack</string>

--- a/app/src/main/res/xml/pref_audio.xml
+++ b/app/src/main/res/xml/pref_audio.xml
@@ -45,6 +45,15 @@
         android:key="bluetooth_playback"
         android:layout="@layout/list_item_view_switch"
         android:summary="@string/pref_summary_bluetooth_playback"
-        android:title="@string/pref_title_bluetooth_playback" />
+        android:title="@string/pref_title_bluetooth_playback"
+        app:icon="@drawable/ic_bluetooth_connect" />
+
+    <code.name.monkey.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+        android:defaultValue="false"
+        android:key="disable_speaker"
+        android:layout="@layout/list_item_view_switch"
+        android:summary="@string/pref_summary_disable_speaker"
+        android:title="@string/pref_title_disable_speaker"
+        app:icon="@drawable/ic_volume_off" />
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Random taps when the phone is in pocket can trigger playing music from speaker when headphones are disconnected. This PR adds opt-in option to disable internal speaker playback when the player is only used for playback on headphones.