### PR TITLE
Fix artist image not refreshing immediately after selection (#1987)

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AbsArtistDetailsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/AbsArtistDetailsFragment.kt
@@ -386,6 +386,8 @@ abstract class AbsArtistDetailsFragment : AbsMainActivityFragment(R.layout.fragm
                 if (uri != null) {
                     CustomArtistImageUtil.getInstance(requireContext())
                         .setCustomArtistImage(artist, uri)
+
+                    detailsViewModel.refreshArtistInfo()
                 }
             }
         }

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/artists/ArtistDetailsViewModel.kt
@@ -42,6 +42,10 @@ class ArtistDetailsViewModel(
         }
     }
 
+    fun refreshArtistInfo(){
+        fetchArtist()
+    }
+
     fun getArtist(): LiveData<Artist> = artistDetails
 
     fun getArtistInfo(


### PR DESCRIPTION
 Add refreshArtistInfo() method to ArtistDetailsViewModel to allow manual refresh of artist data. Call this method in selectImageLauncher
  callback after CustomArtistImageUtil saves the new image.

  This triggers the LiveData observer to reload artist details, which
  calls loadArtistImage() to display the updated image without requiring
  the user to navigate away and back to the artist page.

  Changes:
  - ArtistDetailsViewModel: Add refreshArtistInfo() method that invokes fetchArtist() to re-emit artist data via LiveData
  - AbsArtistDetailsFragment: Call detailsViewModel.refreshArtistInfo() after setCustomArtistImage() completes in the image picker callback
  
  Fix for issue #1987 