### PR TITLE
feat: add ArtistSeparator utility for multi-artist display

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/adapter/song/SongAdapter.kt
@@ -42,6 +42,7 @@ import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.helper.menu.SongMenuHelper
 import code.name.monkey.retromusic.helper.menu.SongsMenuHelper
 import code.name.monkey.retromusic.model.Song
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.MusicUtil
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.RetroUtil
@@ -99,8 +100,11 @@ open class SongAdapter(
         holder.itemView.isActivated = isChecked
         holder.menu?.isGone = isChecked
         holder.title?.text = getSongTitle(song)
-        holder.text?.text = getSongText(song)
-        holder.text2?.text = getSongText(song)
+        
+        // Format artist names using ArtistSeparator
+        val formattedArtistName = ArtistSeparator.split(getSongText(song)).joinToString(", ")
+        holder.text?.text = formattedArtistName
+        holder.text2?.text = formattedArtistName
 
         if (MusicPlayerRemote.currentSong.id == song.id) {
             val context = holder.title?.context

--- a/app/src/main/java/code/name/monkey/retromusic/fragments/other/MiniPlayerFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/other/MiniPlayerFragment.kt
@@ -36,6 +36,7 @@ import code.name.monkey.retromusic.glide.RetroGlideExtension.songCoverOptions
 import code.name.monkey.retromusic.helper.MusicPlayerRemote
 import code.name.monkey.retromusic.helper.MusicProgressViewUpdateHelper
 import code.name.monkey.retromusic.helper.PlayPauseButtonOnClickHandler
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
 import code.name.monkey.retromusic.util.RetroUtil
 import com.bumptech.glide.Glide
@@ -90,7 +91,6 @@ open class MiniPlayerFragment : AbsMusicServiceFragment(R.layout.fragment_mini_p
     }
 
     private fun updateSongTitle() {
-
         val song = MusicPlayerRemote.currentSong
 
         val builder = SpannableStringBuilder()
@@ -98,18 +98,15 @@ open class MiniPlayerFragment : AbsMusicServiceFragment(R.layout.fragment_mini_p
         val title = song.title.toSpannable()
         title.setSpan(ForegroundColorSpan(textColorPrimary()), 0, title.length, 0)
 
-        val text = song.artistName.toSpannable()
+        // Format artist names using ArtistSeparator
+        val formattedArtistName = ArtistSeparator.split(song.artistName).joinToString(", ")
+        val text = formattedArtistName.toSpannable()
         text.setSpan(ForegroundColorSpan(textColorSecondary()), 0, text.length, 0)
 
         builder.append(title).append(" • ").append(text)
 
         binding.miniPlayerTitle.isSelected = true
         binding.miniPlayerTitle.text = builder
-
-//        binding.title.isSelected = true
-//        binding.title.text = song.title
-//        binding.text.isSelected = true
-//        binding.text.text = song.artistName
     }
 
     private fun updateSongCover() {

--- a/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
@@ -1,17 +1,3 @@
-/*
- * Copyright (c) 2020 Hemanth Savarla.
- *
- * Licensed under the GNU General Public License v3
- *
- * This is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- *
- */
 package code.name.monkey.retromusic.util
 
 /**

--- a/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/ArtistSeparator.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Hemanth Savarla.
+ *
+ * Licensed under the GNU General Public License v3
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ */
+package code.name.monkey.retromusic.util
+
+/**
+ * Utility for splitting multi-artist strings into individual artist names.
+ * 
+ * Handles common separators used in audio tags like "/", ";", ",", "feat.", "ft."
+ */
+object ArtistSeparator {
+
+    /**
+     * Array of separators commonly used to delimit multiple artists in metadata.
+     */
+    val SEPARATORS: Array<String> = arrayOf("/", ";", ",", "feat.", "ft.")
+
+    private val regex = SEPARATORS.joinToString("|") { 
+        Regex.escape(it) 
+    }.toRegex(RegexOption.IGNORE_CASE)
+
+    /**
+     * Splits artist names by common separators.
+     * 
+     * Examples:
+     * - `"Artist1 / Artist2"` → `["Artist1", "Artist2"]`
+     * - `"Artist1 feat. Artist2"` → `["Artist1", "Artist2"]`
+     * - `"Artist1, Artist2, Artist3"` → `["Artist1", "Artist2", "Artist3"]`
+     * 
+     * @param artistString The artist name(s) to split
+     * @return List of individual artist names, trimmed and deduplicated. 
+     *         Returns empty list if input is null or empty.
+     */
+    fun split(artistString: String?): List<String> {
+        if (artistString.isNullOrEmpty()) {
+            return emptyList()
+        }
+
+        return artistString.split(regex)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,5 +573,6 @@
     <string name="scan_complete">Scan complete: %1$d media items found.</string>
     <string name="pref_save_last_directory_summary">When switching to folder view, restore last used directory</string>
     <string name="pref_save_last_directory_title">Save Last Directory</string>
+    <string name="artist_separator_helper_text">To add multiple artists, separate them with: %1$s</string>
 
 </resources>


### PR DESCRIPTION

## Summary

Improves readability of songs with multiple artists by formatting them as comma-separated lists instead of showing raw metadata.

## Before/After

**Before:**
```
Song Title
Artist1 / Artist2 feat. Artist3
```

**After:**
```
Song Title
Artist1, Artist2, Artist3
```

## 🔧 Changes

- ✅ **New:** `ArtistSeparator` utility class
  - Splits artist strings by common separators: `/`, `;`, `,`, `feat.`, `ft.`
  - Case-insensitive matching
  - Trims whitespace and removes duplicates
  
- ✅ **Updated:** `SongAdapter`
  - Formats artist names in song lists using `ArtistSeparator`
  
- ✅ **Updated:** `MiniPlayerFragment`  
  - Formats artist names in mini player display
  
- ✅ **Added:** String resource `artist_separator_helper_text`
  - Will be used in tag editor (future PR)

## 🎯 Impact

- 🟢 **Low risk:** Only changes visual display, no navigation/database changes
- 🟢 **No breaking changes:** Fully backwards compatible
- 🟢 **Testable:** `ArtistSeparator.split()` has clear, testable logic

## 🧪 Testing

Tested with:
- ✅ Songs with `/` separator
- ✅ Songs with `feat.` separator  
- ✅ Songs with multiple separators
- ✅ Songs with single artist (no change)
- ✅ Empty/null artist names (handles gracefully)

## 📦 Future Work

This PR lays the groundwork for:
1. Clickable artist links (separate PR)
2. Improved artist navigation (separate PR)
3. Tag editor multi-artist support (separate PR)

## 📝 Notes

- No changes to how data is stored or queried
- Artists are still stored as single strings in MediaStore
- Separation happens only at display time
- String resource added now to avoid future string-only PR