### PR TITLE
fix(whats-new): wrap startActivity in try/catch to avoid ActivityNotFoundException crash

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/WhatsNewFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/WhatsNewFragment.kt
@@ -1,10 +1,12 @@
 package code.name.monkey.retromusic.activities
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -86,9 +88,14 @@ class WhatsNewFragment : BottomSheetDialogFragment() {
                     request: WebResourceRequest?
                 ): Boolean {
                     val url = request?.url ?: return false
-                    //you can do checks here e.g. url.host equals to target one
-                    startActivity(Intent(Intent.ACTION_VIEW, url))
-                    return true
+                    val intent = Intent(Intent.ACTION_VIEW, url)
+                    return try {
+                        startActivity(intent)
+                        true
+                    } catch (e: ActivityNotFoundException) {
+                        Log.w(TAG, "No app available to open $url", e)
+                        true
+                    }
                 }
             }
         } catch (e: Throwable) {


### PR DESCRIPTION
Closes #2011.

`WhatsNewFragment` calls `startActivity(Intent(Intent.ACTION_VIEW, url))` inside `shouldOverrideUrlLoading` without a `try/catch`. On a device whose default browser is disabled (custom ROM, managed work profile) or for any URL scheme nothing on the device handles, the call raises `ActivityNotFoundException` and crashes the host Activity.

### Change

Wrap the launch in `try/catch (ActivityNotFoundException)` and log the unhandled URL. Returning `true` in the catch path keeps the WebView from then trying to load the unsupported scheme itself:

```kotlin
val intent = Intent(Intent.ACTION_VIEW, url)
return try {
    startActivity(intent)
    true
} catch (e: ActivityNotFoundException) {
    Log.w(TAG, "No app available to open $url", e)
    true
}
```

Happy-path behaviour is unchanged. The only difference is that an unhandled URL now logs a warning instead of taking the process down.
