### PR TITLE
feat: add artistByName() repository method

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/LibraryViewModel.kt
@@ -212,7 +212,22 @@ class LibraryViewModel(
     }
 
     fun albumById(id: Long) = repository.albumById(id)
+
     suspend fun artistById(id: Long) = repository.artistById(id)
+
+    /**
+     * Gets an artist by name instead of ID.
+     *
+     * This is useful for navigating to artists from multi-artist songs where
+     * we only have the artist name, not their ID.
+     *
+     * @param name The artist name to search for
+     * @return Artist object with matching songs, or empty artist if not found
+     */
+    fun artistByName(name: String): LiveData<Artist> = liveData(IO) {
+        emit(repository.artistByName(name))
+    }
+
     suspend fun favoritePlaylist() = repository.favoritePlaylist()
     suspend fun isFavoriteSong(song: SongEntity) = repository.isFavoriteSong(song)
     suspend fun isSongFavorite(songId: Long) = repository.isSongFavorite(songId)

--- a/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/ArtistRepository.kt
@@ -19,7 +19,9 @@ import code.name.monkey.retromusic.ALBUM_ARTIST
 import code.name.monkey.retromusic.helper.SortOrder
 import code.name.monkey.retromusic.model.Album
 import code.name.monkey.retromusic.model.Artist
+import code.name.monkey.retromusic.util.ArtistSeparator
 import code.name.monkey.retromusic.util.PreferenceUtil
+import code.name.monkey.retromusic.util.logD
 import java.text.Collator
 
 interface ArtistRepository {
@@ -34,6 +36,8 @@ interface ArtistRepository {
     fun artist(artistId: Long): Artist
 
     fun albumArtist(artistName: String): Artist
+
+    fun artistByName(name: String): Artist
 }
 
 class RealArtistRepository(
@@ -95,6 +99,60 @@ class RealArtistRepository(
             )
         )
         return Artist(artistName, albumRepository.splitIntoAlbums(songs), true)
+    }
+
+    /**
+     * Finds an artist by name, searching across all songs and handling multi-artist metadata.
+     *
+     * This method uses ArtistSeparator to split artist names and find songs where the
+     * specified artist appears (even if they're one of multiple artists on a song).
+     *
+     * @param name The artist name to search for (case-insensitive)
+     * @return Artist object with all matching songs grouped into albums,
+     *         or empty Artist if no songs found
+     */
+    override fun artistByName(name: String): Artist {
+        logD("artistByName: Searching for artist '$name'")
+
+        // Handle special case for Various Artists
+        if (name.equals(Artist.VARIOUS_ARTISTS_DISPLAY_NAME, ignoreCase = true)) {
+            logD("artistByName: Detected Various Artists")
+            return artist(Artist.VARIOUS_ARTISTS_ID)
+        }
+
+        // Get all songs from the media store
+        val allSongs = songRepository.songs(
+            songRepository.makeSongCursor(
+                null,
+                null,
+                getSongLoaderSortOrder()
+            )
+        )
+
+        // Filter songs where the artist name appears
+        // Uses ArtistSeparator to handle multi-artist metadata like "Artist1 / Artist2"
+        val songsForArtist = allSongs.filter { song ->
+            val artistNames = ArtistSeparator.split(song.artistName)
+            artistNames.any { it.equals(name, ignoreCase = true) }
+        }
+
+        logD("artistByName: Found ${songsForArtist.size} songs for '$name'")
+
+        // If no songs found, return empty artist
+        if (songsForArtist.isEmpty()) {
+            logD("artistByName: No songs found for '$name', returning empty artist")
+            return Artist.empty
+        }
+
+        // Group songs into albums
+        val albums = albumRepository.splitIntoAlbums(songsForArtist)
+        logD("artistByName: Grouped into ${albums.size} albums")
+
+        // Generate a stable ID from the artist name
+        // Using hashCode ensures the same name always gets the same ID
+        val artistId = name.hashCode().toLong()
+
+        return Artist(artistId, albums)
     }
 
     override fun artists(): List<Artist> {

--- a/app/src/main/java/code/name/monkey/retromusic/repository/Repository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/Repository.kt
@@ -50,6 +50,7 @@ interface Repository {
     suspend fun artistInfo(name: String, lang: String?, cache: String?): Result<LastFmArtist>
     suspend fun albumInfo(artist: String, album: String): Result<LastFmAlbum>
     suspend fun artistById(artistId: Long): Artist
+    suspend fun artistByName(name: String): Artist
     suspend fun albumArtistByName(name: String): Artist
     suspend fun recentArtists(): List<Artist>
     suspend fun topArtists(): List<Artist>
@@ -141,6 +142,8 @@ class RealRepository(
     override suspend fun albumArtists(): List<Artist> = artistRepository.albumArtists()
 
     override suspend fun artistById(artistId: Long): Artist = artistRepository.artist(artistId)
+
+    override suspend fun artistByName(name: String): Artist = artistRepository.artistByName(name)
 
     override suspend fun albumArtistByName(name: String): Artist =
         artistRepository.albumArtist(name)


### PR DESCRIPTION
## 🎵 Add artistByName() repository method

### Summary

Adds a new repository method to find artists by name instead of ID. This is a prerequisite for implementing navigation from clickable artist links in multi-artist songs.

### Motivation

Currently, artist navigation requires an `artistId` (Long). However, when displaying songs with multiple artists (e.g., "Artist1 / Artist2 feat. Artist3"), we split the names using `ArtistSeparator` and create individual clickable links. When a user clicks "Artist2", we only have the **name**, not the ID.

This PR adds the backend infrastructure to support name-based artist lookup.

### Changes

#### 1. **Repository.kt** (Interface)
- ✅ Added `suspend fun artistByName(name: String): Artist` to interface
- ✅ Implemented in `RealRepository` as passthrough to `ArtistRepository`

#### 2. **ArtistRepository.kt** (Core Logic)
- ✅ Added `artistByName(name: String)` method
- ✅ Searches all songs for matches using `ArtistSeparator.split()`
- ✅ Case-insensitive matching
- ✅ Handles "Various Artists" special case
- ✅ Groups matching songs into albums
- ✅ Generates stable ID using `name.hashCode()`
- ✅ Returns `Artist.empty` if no songs found
- ✅ Includes debug logging

#### 3. **LibraryViewModel.kt** (UI Exposure)
- ✅ Added `artistByName(name: String): LiveData<Artist>`
- ✅ Wraps repository call in coroutine

### How It Works

```kotlin
// User clicks on "Artist2" from "Artist1 / Artist2 feat. Artist3"
val artist = libraryViewModel.artistByName("Artist2")

// Behind the scenes:
// 1. Gets all songs from MediaStore
// 2. Filters songs where ArtistSeparator.split(song.artistName) contains "Artist2"
// 3. Groups matching songs into albums
// 4. Returns Artist object with ID = "Artist2".hashCode()
```

### Example

**Song metadata:** `artistName = "Taylor Swift / Ed Sheeran"`

**Calling `artistByName("Ed Sheeran")`:**
1. Splits "Taylor Swift / Ed Sheeran" → `["Taylor Swift", "Ed Sheeran"]`
2. Finds match for "Ed Sheeran"
3. Returns Artist with all Ed Sheeran's songs (including collaborations)

### Technical Notes

- **ID Generation:** Uses `name.hashCode().toLong()` for stable, consistent IDs
- **Performance:** Scans all songs in memory (acceptable since this is called on-demand)
- **Case Handling:** Case-insensitive matching via `equals(ignoreCase = true)`
- **Empty Results:** Returns `Artist.empty` instead of throwing exception

### Testing Checklist

- [ ] Compiles without errors
- [ ] Method callable from ViewModel
- [ ] Returns valid Artist for existing artist names
- [ ] Returns `Artist.empty` for non-existent names
- [ ] Handles "Various Artists" correctly
- [ ] Case-insensitive matching works

### Future Work

**This method is intentionally unused in this PR.** It will be connected to the UI in the next PR:

**Next PR (planned):** Connect clickable artist links to navigation
- Update 4 player fragments from #2003
- Replace Toast placeholders with actual navigation
- Use `artistByName()` to navigate to artist details

### Related PRs

- **Full multi-artist refactor →#1932 (not merged - too large) 
- **Add ArtistSeparator utility** → #2001 ✅ merged
- **Add clickable artist links UI** → #2003 ✅ merged
- **This PR:** Add `artistByName()` backend method
- **Next PR (planned):** Connect clickable artist links to navigation

---

**Why split into separate PRs?**
- ✅ Easier to review (3 files vs 56 files)
- ✅ Each PR has single focus
- ✅ Can be tested independently
- ✅ Safer to merge incrementally