### PR TITLE
fix infinite media notification spawn bug.

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
@@ -138,6 +138,8 @@ class MusicService : MediaBrowserServiceCompat(),
     @JvmField
     var pendingQuit = false
 
+    private var isQuitting = false
+
     private lateinit var playbackManager: PlaybackManager
 
     val playback: Playback? get() = playbackManager.playback
@@ -720,6 +722,13 @@ class MusicService : MediaBrowserServiceCompat(),
         return START_NOT_STICKY
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        if (!isPlaying) {
+            quit()
+        }
+    }
+
     override fun onTrackEnded() {
         acquireWakeLock()
         // if there is a timer finished, don't continue
@@ -879,7 +888,8 @@ class MusicService : MediaBrowserServiceCompat(),
     }
 
     fun quit() {
-        pause()
+        isQuitting = true
+        pause(true)
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         isForeground = false
         notificationManager?.cancel(PlayingNotification.NOTIFICATION_ID)
@@ -1181,6 +1191,7 @@ class MusicService : MediaBrowserServiceCompat(),
     }
 
     private fun startForegroundOrNotify() {
+        if (isQuitting) return
         if (playingNotification != null && currentSong.id != -1L) {
             if (isForeground && !isPlaying) {
                 // This makes the notification dismissible

--- a/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/service/MusicService.kt
@@ -722,13 +722,6 @@ class MusicService : MediaBrowserServiceCompat(),
         return START_NOT_STICKY
     }
 
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        if (!isPlaying) {
-            quit()
-        }
-    }
-
     override fun onTrackEnded() {
         acquireWakeLock()
         // if there is a timer finished, don't continue


### PR DESCRIPTION
-After closing the app from the recents, the media notification always stays even if i swipe and clear, it just spawns back again and again, So everytime i had to force stop the app in the settings.

-It is now fixed.
