### PR TITLE
Fix sidecar lyrics path for MIDI files

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/util/LyricUtil.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/util/LyricUtil.kt
@@ -118,7 +118,9 @@ object LyricUtil {
     }
 
     private fun getLrcOriginalPath(filePath: String): String {
-        return filePath.replace(filePath.substring(filePath.lastIndexOf(".") + 1), "lrc")
+        val file = File(filePath)
+        val lrcName = "${file.nameWithoutExtension}.lrc"
+        return file.parentFile?.resolve(lrcName)?.path ?: lrcName
     }
 
     @Throws(Exception::class)


### PR DESCRIPTION
When computing sidecar file paths the replace used to scramble directory names.

E.g. `Music/midi/track.mid` would turn into `Music/lrci/track.lrc` instead of `Music/midi/track.lrc`