### PR TITLE
feat: Added "Date Added" sorting for Albums

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumsFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/albums/AlbumsFragment.kt
@@ -191,8 +191,15 @@ class AlbumsFragment : AbsRecyclerViewCustomGridSizeFragment<AlbumAdapter, GridL
             currentSortOrder.equals(AlbumSortOrder.ALBUM_YEAR)
         sortOrderMenu.add(
             0,
-            R.id.action_album_sort_order_num_songs,
+            R.id.action_album_sort_order_dateadded,
             4,
+            R.string.sort_order_date
+        ).isChecked =
+            currentSortOrder.equals(AlbumSortOrder.ALBUM_DATE_ADDED)
+        sortOrderMenu.add(
+            0,
+            R.id.action_album_sort_order_num_songs,
+            5,
             R.string.sort_order_num_songs
         ).isChecked =
             currentSortOrder.equals(AlbumSortOrder.ALBUM_NUMBER_OF_SONGS)
@@ -272,6 +279,7 @@ class AlbumsFragment : AbsRecyclerViewCustomGridSizeFragment<AlbumAdapter, GridL
             R.id.action_album_sort_order_desc -> AlbumSortOrder.ALBUM_Z_A
             R.id.action_album_sort_order_artist -> AlbumSortOrder.ALBUM_ARTIST
             R.id.action_album_sort_order_year -> AlbumSortOrder.ALBUM_YEAR
+            R.id.action_album_sort_order_dateadded -> AlbumSortOrder.ALBUM_DATE_ADDED
             R.id.action_album_sort_order_num_songs -> AlbumSortOrder.ALBUM_NUMBER_OF_SONGS
             else -> PreferenceUtil.albumSortOrder
         }

--- a/app/src/main/java/code/name/monkey/retromusic/helper/SortOrder.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/helper/SortOrder.kt
@@ -62,6 +62,9 @@ class SortOrder {
 
             /* Album sort order year */
             const val ALBUM_YEAR = MediaStore.Audio.Media.YEAR + " DESC"
+
+            /* Album sort order by date added to library */
+            const val ALBUM_DATE_ADDED = MediaStore.Audio.Media.DATE_ADDED + " DESC"
         }
     }
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -8,6 +8,7 @@
     <item name="action_album_sort_order_desc" type="id" />
     <item name="action_album_sort_order_artist" type="id" />
     <item name="action_album_sort_order_year" type="id" />
+    <item name="action_album_sort_order_dateadded" type="id" />
     <item name="action_album_sort_order_num_songs" type="id" />
     <item name="action_import_playlist" type="id" />
     <item name="action_artist_sort_order_asc" type="id" />


### PR DESCRIPTION
With some poking around, I've added a sorting option for Albums by Date Added to library. This makes Albums you've added most recently appear at the top. Tiny thing I slipped in for my own personal taste.

If there's anything missing that would be needed for official inclusion, let me know!

<img width="540" height="672" alt="Screenshot_20260713-133830_1" src="https://github.com/user-attachments/assets/33561179-424c-4c3a-833e-6a9428893552" />