### PR TITLE
Fix: Add padding to Folder View to prevent last item being obscured

### DIFF
--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -54,6 +54,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
+            android:paddingBottom="56dp"
             android:layoutAnimation="@anim/layout_animation_fall_down"
             android:scrollbars="none"
             app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />


### PR DESCRIPTION
Added android:paddingBottom="56dp" to the RecyclerView. Since clipToPadding="false" is already implemented, this provides the exact amount of scrolling space needed at the bottom so the last item isn't hidden behind the mini-player