### PR TITLE
Fix: Add padding to Folder View to prevent last item being obscured

### DIFF
--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -11,6 +11,7 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingBottom="56dp"
         android:clipToPadding="false"
         android:overScrollMode="@integer/overScrollMode"
         android:scrollbars="none"


### PR DESCRIPTION
Added android:paddingBottom="56dp" to the RecyclerView. Since clipToPadding="false" is already implemented, this provides the exact amount of scrolling space needed at the bottom so the last item isn't hidden behind the mini-player.