### PR TITLE
​Fix: Prevent mini-player from overlapping last item in Folder View

### DIFF
--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -12,6 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
+        android:paddingBottom="56dp"
         android:overScrollMode="@integer/overScrollMode"
         android:scrollbars="none"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />


### PR DESCRIPTION
I noticed a minor UI issue in the Folder View where the last item in the list is partially or completely hidden behind the mini-player when scrolling to the very bottom.

**Changes made:**
Added `android:paddingBottom="56dp"` to the `InsetsRecyclerView` in `fragment_folder.xml`. 

Since `android:clipToPadding="false"` is already implemented in this view, adding this specific padding (which matches the standard mini-player height) provides the exact amount of scrolling space needed at the bottom without cutting off any content. 

This small tweak makes the UX feel much more polished. Thank you for maintaining such a great app!