### PR TITLE
Fix .opus files being excluded from folder browsing and media scan

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/util/FileUtil.java
+++ b/app/src/main/java/code/name/monkey/retromusic/util/FileUtil.java
@@ -37,9 +37,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import code.name.monkey.retromusic.Constants;
@@ -49,6 +51,15 @@ import code.name.monkey.retromusic.repository.RealSongRepository;
 import code.name.monkey.retromusic.repository.SortedCursor;
 
 public final class FileUtil {
+
+  // android.webkit.MimeTypeMap lacks entries for these audio extensions on many
+  // Android versions/OEM builds, so fileIsMimeType() falls back to this table.
+  private static final Map<String, String> EXTENSION_MIME_FALLBACK = new HashMap<>();
+
+  static {
+    EXTENSION_MIME_FALLBACK.put("opus", "audio/opus");
+    EXTENSION_MIME_FALLBACK.put("oga", "audio/ogg");
+  }
 
   private FileUtil() {}
 
@@ -181,6 +192,13 @@ public final class FileUtil {
       }
       String fileExtension = filename.substring(dotPos + 1).toLowerCase(Locale.ROOT);
       String fileType = mimeTypeMap.getMimeTypeFromExtension(fileExtension);
+      if (fileType == null) {
+        // android.webkit.MimeTypeMap does not know about some audio extensions
+        // (e.g. "opus") on many Android versions/OEM builds, even though the
+        // platform's media stack can decode them. Fall back to a manual map so
+        // those files aren't silently excluded from audio filters.
+        fileType = EXTENSION_MIME_FALLBACK.get(fileExtension);
+      }
       if (fileType == null) {
         return false;
       }


### PR DESCRIPTION
## What

`.opus` files are silently excluded from the Folder browser and from the "Scan Media" action, so they never get handed to Android's media scanner and never end up in the library.

## Root cause

`FoldersFragment.AUDIO_FILE_FILTER` filters files via `FileUtil.fileIsMimeType(file, "audio/*", MimeTypeMap.getSingleton())`, which calls `android.webkit.MimeTypeMap.getMimeTypeFromExtension("opus")`. Stock Android's built-in MIME database has no entry for the `opus` extension on most versions/OEM builds, so that call returns `null`, and `fileIsMimeType()` returns `false` immediately (`FileUtil.java` line ~184) -- before ever reaching the `application/opus` / `application/ogg` fallback checks already present in the filter. Those extra checks never fire, because they hit the same `null` on the same broken lookup.

Net effect: `.opus` files don't show up in the Folder browser, and get skipped when scanning a folder for new music, so they never get indexed into `MediaStore` and never appear in the Songs library either. Playback itself (ExoPlayer in `RetroExoPlayer` / `MediaPlayer` in `CrossFadePlayer`) already handles Opus fine -- Android's had a mandatory software Opus decoder since API 21 — so this is purely a discovery bug, not a playback one.

## Fix

`FileUtil.fileIsMimeType()` now falls back to a small manual extension→MIME table (`opus` → `audio/opus`, `oga` → `audio/ogg`) when the platform's `MimeTypeMap` doesn't recognize the extension.

## Related history

This exact symptom was reported and closed as fixed in #748 back in 2021 -- likely by the `application/opus`/`application/ogg` checks that are still in `FoldersFragment` today, which happened to mask the bug on whichever device the fix was verified on (some OEM `MimeTypeMap` builds do carry an `opus` entry), but not on stock/AOSP-derived ones. #1759 and #1615 are more recent reports of general opus trouble that got closed as "OS/device codec support," but that's a different question from *discovery* -- the file is never offered to the codec at all if it's filtered out before scanning.

## Testing

Built and installed a debug APK (`app-normal-debug.apk`, `assembleNormalDebug`) on a physical device (LG V60 ThinQ, Android 13) with a folder of `.opus` files: before the fix they were invisible in Folder view and skipped by Scan Media; after the fix they show up, get scanned, and play correctly.
