### PR TITLE
Fix ViewPager crash when a playing song is removed from device

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/fragments/player/PlayerAlbumCoverFragment.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/fragments/player/PlayerAlbumCoverFragment.kt
@@ -71,7 +71,13 @@ class PlayerAlbumCoverFragment : AbsMusicServiceFragment(), ViewPager.OnPageChan
     }
 
     override fun onPlayingMetaChanged() {
-        viewPager.currentItem = MusicPlayerRemote.position
+        val adapter = viewPager.adapter
+        val queueSize = MusicPlayerRemote.playingQueue.size
+        if (adapter == null || adapter.count != queueSize) {
+            updatePlayingQueue()
+            return
+        }
+        viewPager.currentItem = MusicPlayerRemote.position.coerceIn(0, queueSize - 1)
     }
 
     override fun onQueueChanged() {


### PR DESCRIPTION
Fixes #1787.

Multi-selecting songs from the library and hitting "remove from device" while one of them is playing throws:

```
IllegalStateException: The application's PagerAdapter changed the adapter's contents without calling PagerAdapter#notifyDataSetChanged! Expected adapter item count: 176, found: 174
```

The delete triggers a meta-changed broadcast whose handler in `PlayerAlbumCoverFragment.onPlayingMetaChanged` sets `viewPager.currentItem` directly. `AlbumCoverPagerAdapter.dataSet` is passed by reference — the very same `MusicPlayerRemote.playingQueue` list — so once the songs are removed, `getCount()` returns the new smaller size, ViewPager sees the silent count change, and crashes before `onQueueChanged` gets to rebuild the adapter.

The fix rebuilds the adapter when the queue size no longer matches `adapter.count`, and coerces `currentItem` into the new valid range so the last-song-deleted case doesn't `IndexOutOfBounds` either.

### Repro on 6.1.0

1. Start playing a song from Library → Songs.
2. Long-press to enter selection mode, select the currently playing song + 1 or 2 others.
3. Overflow → **Remove from device** → confirm.

Before: crash as above.  
After: playback stops, queue updates, ViewPager rebuilds cleanly.